### PR TITLE
Fix a usage issue with the demo applications with zero arguments

### DIFF
--- a/demo_create.c
+++ b/demo_create.c
@@ -42,6 +42,12 @@ parse_arguments(int argc, char **argv,
                 char **client_certificate, char **client_key, char **ca_certificate,
                 int *print_usage)
 {
+    if(argc <= 1)
+    {
+        print_help(argv[0]);
+        return(-1);
+    }
+    
     for(int i = 1; i < argc; i++)
     {
         if(strncmp(argv[i], "-a", 2) == 0)

--- a/demo_destroy.c
+++ b/demo_destroy.c
@@ -43,6 +43,12 @@ parse_arguments(int argc, char **argv,
                 char **id,
                 int *print_usage)
 {
+    if(argc <= 1)
+    {
+        print_help(argv[0]);
+        return(-1);
+    }
+    
     for(int i = 1; i < argc; i++)
     {
         if(strncmp(argv[i], "-a", 2) == 0)

--- a/demo_get.c
+++ b/demo_get.c
@@ -47,6 +47,12 @@ parse_arguments(int argc, char **argv,
                 char **id,
                 int *print_usage)
 {
+    if(argc <= 1)
+    {
+        print_help(argv[0]);
+        return(-1);
+    }
+    
     for(int i = 1; i < argc; i++)
     {
         if(strncmp(argv[i], "-a", 2) == 0)


### PR DESCRIPTION
This change improves argument handling for the demo applications, adding explicit checks for when zero command-line arguments are provided. This case was originally unhandled and could lead to errors and segmentation faults. Now the applications will detect this case and will print out usage information to help the user.