### PR TITLE
Update the linked list implementation to a doubly linked list

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -65,6 +65,11 @@ kmip_linked_list_pop(LinkedList *list)
         {
             list->head->prev = NULL;
         }
+
+        if(popped == list->tail)
+        {
+            list->tail = NULL;
+        }
         
         if(list->size > 0)
         {
@@ -96,6 +101,11 @@ kmip_linked_list_push(LinkedList *list, LinkedListItem *item)
         if(head != NULL)
         {
             head->prev = item;
+        }
+
+        if(list->tail == NULL)
+        {
+            list->tail = list->head;
         }
     }
 }

--- a/kmip.h
+++ b/kmip.h
@@ -674,6 +674,8 @@ typedef struct linked_list_item
 typedef struct linked_list
 {
     LinkedListItem *head;
+    LinkedListItem *tail;
+
     size_t size;
 } LinkedList;
 


### PR DESCRIPTION
This change updates the linked list implementation in libkmip to be a doubly linked list. The push and pop functions have been updated accordingly. Two new test functions verifying the correctness of push and pop have also been added.