### PR TITLE
Add a peek function to read a tag from a context buffer

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -1455,6 +1455,24 @@ kmip_get_num_items_next(KMIP *ctx, enum tag t)
     return(count);
 }
 
+int
+kmip_peek_tag(KMIP *ctx)
+{
+    if(BUFFER_BYTES_LEFT(ctx) < 3)
+    {
+        return(0);
+    }
+
+    uint8 *index = ctx->index;
+    int32 tag = 0;
+
+    tag |= ((int32)*index++ << 16);
+    tag |= ((int32)*index++ << 8);
+    tag |= ((int32)*index++ << 0);
+
+    return(tag);
+}
+
 /*
 Initialization Functions
 */

--- a/kmip.h
+++ b/kmip.h
@@ -1024,6 +1024,8 @@ Macros
 
 #define ARRAY_LENGTH(A) (sizeof((A)) / sizeof((A)[0]))
 
+#define BUFFER_BYTES_LEFT(A) ((A)->size - ((A)->index - (A)->buffer))
+
 #define CHECK_BUFFER_FULL(A, B)                         \
 do                                                      \
 {                                                       \
@@ -1160,6 +1162,7 @@ void kmip_set_error_message(KMIP *, const char *);
 int kmip_is_tag_next(const KMIP *, enum tag);
 int kmip_is_tag_type_next(const KMIP *, enum tag, enum type);
 int kmip_get_num_items_next(KMIP *, enum tag);
+int kmip_peek_tag(KMIP *);
 
 /*
 Initialization Functions


### PR DESCRIPTION
This change adds a peek function that will read a 3-byte tag from the context buffer without modifying the context fields or the buffer itself. If the buffer does not contain enough bytes, 0 is returned.

This change also adds a new macro to calculate the number of bytes left in the buffer given the tracked buffer size and the current buffer index stored in the context.

Unit tests have been added for both the peek function and the buffer bytes macro.