### PR TITLE
Redirect OpenSSL install output to a log file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - pushd ~/build/openssl/openssl-1.1.0i
   - ./Configure enable-crypto-mdebug enable-crypto-mdebug-backtrace linux-x86_64
   - make &> ~/build/openssl/openssl-1.1.0i-make.log
-  - sudo make install
+  - sudo make install &> ~/build/openssl/openssl-1.1.0i-make-install.log
   - popd
 
 script:


### PR DESCRIPTION
This change updates the Travis CI configuration file to redirect the OpenSSL install output to a log file. The output takes up thousands of lines in the Travis CI job log, wasting space and taking time to analyze and scroll through.

Fixes #9