### PR TITLE
Add support for ProtectionStorageMasks

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -163,7 +163,7 @@ kmip_free(void *state, void *ptr)
 Enumeration Utilities
 */
 
-static const char *kmip_attribute_names[25] = {
+static const char *kmip_attribute_names[26] = {
     "Attestation Type",
     "BatchErrorContinuation Option",
     "BlockCipher Mode",
@@ -182,6 +182,7 @@ static const char *kmip_attribute_names[25] = {
     "Object Type",
     "Operation",
     "Padding Method",
+    "Protection Storage Mask",
     "Result Reason",
     "Result Status",
     "State",
@@ -267,33 +268,37 @@ kmip_get_enum_string_index(enum tag t)
         case KMIP_TAG_PADDING_METHOD:
         return(17);
         break;
-        
-        case KMIP_TAG_RESULT_REASON:
+
+        case KMIP_TAG_PROTECTION_STORAGE_MASK:
         return(18);
         break;
         
-        case KMIP_TAG_RESULT_STATUS:
+        case KMIP_TAG_RESULT_REASON:
         return(19);
         break;
         
-        case KMIP_TAG_STATE:
+        case KMIP_TAG_RESULT_STATUS:
         return(20);
         break;
         
-        case KMIP_TAG_TAG:
+        case KMIP_TAG_STATE:
         return(21);
         break;
         
-        case KMIP_TAG_TYPE:
+        case KMIP_TAG_TAG:
         return(22);
         break;
         
-        case KMIP_TAG_WRAPPING_METHOD:
+        case KMIP_TAG_TYPE:
         return(23);
         break;
         
-        default:
+        case KMIP_TAG_WRAPPING_METHOD:
         return(24);
+        break;
+        
+        default:
+        return(25);
         break;
     };
 }
@@ -890,6 +895,38 @@ kmip_check_enum_value(enum kmip_version version, enum tag t, int value)
             default:
             return(KMIP_ENUM_MISMATCH);
             break;
+        };
+        break;
+
+        case KMIP_TAG_PROTECTION_STORAGE_MASK:
+        {
+            switch(value)
+            {
+                /* KMIP 2.0 */
+                case KMIP_PROTECT_SOFTWARE:
+                case KMIP_PROTECT_HARDWARE:
+                case KMIP_PROTECT_ON_PROCESSOR:
+                case KMIP_PROTECT_ON_SYSTEM:
+                case KMIP_PROTECT_OFF_SYSTEM:
+                case KMIP_PROTECT_HYPERVISOR:
+                case KMIP_PROTECT_OPERATING_SYSTEM:
+                case KMIP_PROTECT_CONTAINER:
+                case KMIP_PROTECT_ON_PREMISES:
+                case KMIP_PROTECT_OFF_PREMISES:
+                case KMIP_PROTECT_SELF_MANAGED:
+                case KMIP_PROTECT_OUTSOURCED:
+                case KMIP_PROTECT_VALIDATED:
+                case KMIP_PROTECT_SAME_JURISDICTION:
+                if(version >= KMIP_2_0)
+                    return(KMIP_OK);
+                else
+                    return(KMIP_INVALID_FOR_VERSION);
+                break;
+
+                default:
+                return(KMIP_ENUM_MISMATCH);
+                break;
+            };
         };
         break;
         
@@ -3443,6 +3480,104 @@ kmip_print_cryptographic_usage_mask_enums(int indent, int32 value)
 }
 
 void
+kmip_print_protection_storage_mask_enum(int indent, int32 value)
+{
+    printf("\n");
+
+    if((value & KMIP_PROTECT_SOFTWARE) == KMIP_PROTECT_SOFTWARE)
+    {
+        printf("%*sSoftware\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_HARDWARE) == KMIP_PROTECT_HARDWARE)
+    {
+        printf("%*sHardware\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_ON_PROCESSOR) == KMIP_PROTECT_ON_PROCESSOR)
+    {
+        printf("%*sOn Processor\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_ON_SYSTEM) == KMIP_PROTECT_ON_SYSTEM)
+    {
+        printf("%*sOn System\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_OFF_SYSTEM) == KMIP_PROTECT_OFF_SYSTEM)
+    {
+        printf("%*sOff System\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_HYPERVISOR) == KMIP_PROTECT_HYPERVISOR)
+    {
+        printf("%*sHypervisor\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_OPERATING_SYSTEM) == KMIP_PROTECT_OPERATING_SYSTEM)
+    {
+        printf("%*sOperating System\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_CONTAINER) == KMIP_PROTECT_CONTAINER)
+    {
+        printf("%*sContainer\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_ON_PREMISES) == KMIP_PROTECT_ON_PREMISES)
+    {
+        printf("%*sOn Premises\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_OFF_PREMISES) == KMIP_PROTECT_OFF_PREMISES)
+    {
+        printf("%*sOff Premises\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_SELF_MANAGED) == KMIP_PROTECT_SELF_MANAGED)
+    {
+        printf("%*sSelf Managed\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_OUTSOURCED) == KMIP_PROTECT_OUTSOURCED)
+    {
+        printf("%*sOutsourced\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_VALIDATED) == KMIP_PROTECT_VALIDATED)
+    {
+        printf("%*sValidated\n", indent, "");
+    }
+
+    if((value & KMIP_PROTECT_SAME_JURISDICTION) == KMIP_PROTECT_SAME_JURISDICTION)
+    {
+        printf("%*sSame Jurisdiction\n", indent, "");
+    }
+}
+
+void
+kmip_print_protection_storage_masks(int indent, ProtectionStorageMasks *value)
+{
+    printf("%*sProtection Storage Masks @ %p\n", indent, "", (void *)value);
+
+    if(value != NULL)
+    {
+        printf("%*sMasks: %zu\n", indent + 2, "", value->masks->size);
+        LinkedListItem *curr = value->masks->head;
+        size_t count = 1;
+        while(curr != NULL)
+        {
+            printf("%*sMask: %zu", indent + 4, "", count);
+            int32 mask = *(int32 *)curr->data;
+            kmip_print_protection_storage_mask_enum(indent + 6, mask);
+
+            curr = curr->next;
+            count++;
+        }
+    }
+}
+
+void
 kmip_print_integer(int32 value)
 {
     switch(value)
@@ -4424,6 +4559,29 @@ kmip_free_name(KMIP *ctx, Name *value)
         value->type = 0;
     }
     
+    return;
+}
+
+void
+kmip_free_protection_storage_masks(KMIP *ctx, ProtectionStorageMasks *value)
+{
+    if(value != NULL)
+    {
+        if(value->masks != NULL)
+        {
+            LinkedListItem *curr = kmip_linked_list_pop(value->masks);
+            while(curr != NULL)
+            {
+                ctx->free_func(ctx->state, curr->data);
+                curr->data = NULL;
+                ctx->free_func(ctx->state, curr);
+                curr = kmip_linked_list_pop(value->masks);
+            }
+            ctx->free_func(ctx->state, value->masks);
+            value->masks = NULL;
+        }
+    }
+
     return;
 }
 
@@ -5603,6 +5761,56 @@ kmip_compare_name(const Name *a, const Name *b)
         }
     }
     
+    return(KMIP_TRUE);
+}
+
+int
+kmip_compare_protection_storage_masks(const ProtectionStorageMasks *a, const ProtectionStorageMasks *b)
+{
+    if(a != b)
+    {
+        if((a == NULL) || (b == NULL))
+        {
+            return(KMIP_FALSE);
+        }
+
+        if((a->masks != b->masks))
+        {
+            if((a->masks == NULL) || (b->masks == NULL))
+            {
+                return(KMIP_FALSE);
+            }
+
+            if((a->masks->size != b->masks->size))
+            {
+                return(KMIP_FALSE);
+            }
+
+            LinkedListItem *a_item = a->masks->head;
+            LinkedListItem *b_item = b->masks->head;
+            while((a_item != NULL) || (b_item != NULL))
+            {
+                if(a_item != b_item)
+                {
+                    int32 a_data = *(int32 *)a_item->data;
+                    int32 b_data = *(int32 *)b_item->data;
+                    if(a_data != b_data)
+                    {
+                        return(KMIP_FALSE);
+                    }
+                }
+
+                a_item = a_item->next;
+                b_item = b_item->next;
+            }
+
+            if(a_item != b_item)
+            {
+                return(KMIP_FALSE);
+            }
+        }
+    }
+
     return(KMIP_TRUE);
 }
 
@@ -7712,6 +7920,46 @@ kmip_encode_name(KMIP *ctx, const Name *value)
 }
 
 int
+kmip_encode_protection_storage_masks(KMIP *ctx, const ProtectionStorageMasks *value)
+{
+    CHECK_ENCODE_ARGS(ctx, value);
+    CHECK_KMIP_VERSION(ctx, KMIP_2_0);
+
+    int result = 0;
+
+    result = kmip_encode_int32_be(
+        ctx,
+        TAG_TYPE(KMIP_TAG_PROTECTION_STORAGE_MASKS, KMIP_TYPE_STRUCTURE)
+    );
+    CHECK_RESULT(ctx, result);
+
+    uint8 *length_index = ctx->index;
+    uint8 *value_index = ctx->index += 4;
+
+    if(value->masks != NULL)
+    {
+        LinkedListItem *curr = value->masks->head;
+        while(curr != NULL)
+        {
+            result = kmip_encode_integer(ctx, KMIP_TAG_PROTECTION_STORAGE_MASK, *(int32 *)curr->data);
+            CHECK_RESULT(ctx, result);
+
+            curr = curr->next;
+        }
+    }
+
+    uint8 *curr_index = ctx->index;
+    ctx->index = length_index;
+
+    result = kmip_encode_int32_be(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
+    ctx->index = curr_index;
+
+    return(KMIP_OK);
+}
+
+int
 kmip_encode_attribute_name(KMIP *ctx, enum attribute_type value)
 {
     int result = 0;
@@ -9742,6 +9990,47 @@ kmip_decode_attribute_name(KMIP *ctx, enum attribute_type *value)
     }
     
     kmip_free_text_string(ctx, &n);
+    return(KMIP_OK);
+}
+
+int
+kmip_decode_protection_storage_masks(KMIP *ctx, ProtectionStorageMasks *value)
+{
+    CHECK_DECODE_ARGS(ctx, value);
+    CHECK_KMIP_VERSION(ctx, KMIP_2_0);
+    CHECK_BUFFER_FULL(ctx, 8);
+
+    int result = 0;
+    int32 tag_type = 0;
+    uint32 length = 0;
+
+    result = kmip_decode_int32_be(ctx, &tag_type);
+    CHECK_RESULT(ctx, result);
+    CHECK_TAG_TYPE(ctx, tag_type, KMIP_TAG_PROTECTION_STORAGE_MASKS, KMIP_TYPE_STRUCTURE);
+
+    result = kmip_decode_int32_be(ctx, &length);
+    CHECK_RESULT(ctx, result);
+    CHECK_BUFFER_FULL(ctx, length);
+
+    value->masks = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    CHECK_NEW_MEMORY(ctx, value->masks, sizeof(LinkedList), "LinkedList");
+
+    uint32 tag = kmip_peek_tag(ctx);
+    while(tag == KMIP_TAG_PROTECTION_STORAGE_MASK)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        CHECK_NEW_MEMORY(ctx, item, sizeof(LinkedListItem), "LinkedListItem");
+        kmip_linked_list_enqueue(value->masks, item);
+
+        item->data = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+        CHECK_NEW_MEMORY(ctx, item->data, sizeof(int32), "Protection Storage Mask");
+
+        result = kmip_decode_integer(ctx, KMIP_TAG_PROTECTION_STORAGE_MASK, (int32 *)item->data);
+        CHECK_RESULT(ctx, result);
+
+        tag = kmip_peek_tag(ctx);
+    }
+
     return(KMIP_OK);
 }
 

--- a/kmip.h
+++ b/kmip.h
@@ -427,6 +427,25 @@ enum padding_method
     KMIP_PAD_PSS       = 0x0A
 };
 
+enum protection_storage_mask
+{
+    /* KMIP 2.0 */
+    KMIP_PROTECT_SOFTWARE          = 0x00000001,
+    KMIP_PROTECT_HARDWARE          = 0x00000002,
+    KMIP_PROTECT_ON_PROCESSOR      = 0x00000004,
+    KMIP_PROTECT_ON_SYSTEM         = 0x00000008,
+    KMIP_PROTECT_OFF_SYSTEM        = 0x00000010,
+    KMIP_PROTECT_HYPERVISOR        = 0x00000020,
+    KMIP_PROTECT_OPERATING_SYSTEM  = 0x00000040,
+    KMIP_PROTECT_CONTAINER         = 0x00000080,
+    KMIP_PROTECT_ON_PREMISES       = 0x00000100,
+    KMIP_PROTECT_OFF_PREMISES      = 0x00000200,
+    KMIP_PROTECT_SELF_MANAGED      = 0x00000400,
+    KMIP_PROTECT_OUTSOURCED        = 0x00000800,
+    KMIP_PROTECT_VALIDATED         = 0x00001000,
+    KMIP_PROTECT_SAME_JURISDICTION = 0x00002000
+};
+
 enum result_reason
 {
     /* KMIP 1.0 */
@@ -633,7 +652,12 @@ enum tag
     KMIP_TAG_CLIENT_CORRELATION_VALUE         = 0x420105,
     KMIP_TAG_SERVER_CORRELATION_VALUE         = 0x420106,
     /* KMIP 2.0 */
-    KMIP_TAG_ATTRIBUTES                       = 0x420125
+    KMIP_TAG_ATTRIBUTES                       = 0x420125,
+    KMIP_TAG_PROTECTION_STORAGE_MASK          = 0x42015E,
+    KMIP_TAG_PROTECTION_STORAGE_MASKS         = 0x42015F,
+    KMIP_TAG_COMMON_PROTECTION_STORAGE_MASKS  = 0x420163,
+    KMIP_TAG_PRIVATE_PROTECTION_STORAGE_MASKS = 0x420164,
+    KMIP_TAG_PUBLIC_PROTECTION_STORAGE_MASKS  = 0x420165
 };
 
 enum type
@@ -761,6 +785,12 @@ typedef struct protocol_version
     int32 major;
     int32 minor;
 } ProtocolVersion;
+
+typedef struct protection_storage_masks
+{
+    /* KMIP 2.0 */
+    LinkedList *masks;
+} ProtectionStorageMasks;
 
 typedef struct cryptographic_parameters
 {
@@ -1255,6 +1285,8 @@ void kmip_print_byte_string(int, const char *, ByteString *);
 void kmip_print_protocol_version(int, ProtocolVersion *);
 void kmip_print_name(int, Name *);
 void kmip_print_nonce(int, Nonce *);
+void kmip_print_protection_storage_masks_enum(int, int32);
+void kmip_print_protection_storage_masks(int, ProtectionStorageMasks *);
 void kmip_print_cryptographic_parameters(int, CryptographicParameters *);
 void kmip_print_encryption_key_information(int, EncryptionKeyInformation *);
 void kmip_print_mac_signature_key_information(int, MACSignatureKeyInformation *);
@@ -1304,6 +1336,7 @@ void kmip_free_template_attribute(KMIP *, TemplateAttribute *);
 void kmip_free_transparent_symmetric_key(KMIP *, TransparentSymmetricKey *);
 void kmip_free_key_material(KMIP *, enum key_format_type, void **);
 void kmip_free_key_value(KMIP *, enum key_format_type, KeyValue *);
+void kmip_free_protection_storage_masks(KMIP *, ProtectionStorageMasks *);
 void kmip_free_cryptographic_parameters(KMIP *, CryptographicParameters *);
 void kmip_free_encryption_key_information(KMIP *, EncryptionKeyInformation *);
 void kmip_free_mac_signature_key_information(KMIP *, MACSignatureKeyInformation *);
@@ -1347,6 +1380,7 @@ int kmip_compare_protocol_version(const ProtocolVersion *, const ProtocolVersion
 int kmip_compare_transparent_symmetric_key(const TransparentSymmetricKey *, const TransparentSymmetricKey *);
 int kmip_compare_key_material(enum key_format_type, void **, void **);
 int kmip_compare_key_value(enum key_format_type, const KeyValue *, const KeyValue *);
+int kmip_compare_protection_storage_masks(const ProtectionStorageMasks *, const ProtectionStorageMasks *);
 int kmip_compare_cryptographic_parameters(const CryptographicParameters *, const CryptographicParameters *);
 int kmip_compare_encryption_key_information(const EncryptionKeyInformation *, const EncryptionKeyInformation *);
 int kmip_compare_mac_signature_key_information(const MACSignatureKeyInformation *, const MACSignatureKeyInformation *);
@@ -1399,6 +1433,7 @@ int kmip_encode_attribute(KMIP *, const Attribute *);
 int kmip_encode_attributes(KMIP *, const Attributes *);
 int kmip_encode_template_attribute(KMIP *, const TemplateAttribute *);
 int kmip_encode_protocol_version(KMIP *, const ProtocolVersion *);
+int kmip_encode_protection_storage_masks(KMIP *, const ProtectionStorageMasks *);
 int kmip_encode_cryptographic_parameters(KMIP *, const CryptographicParameters *);
 int kmip_encode_encryption_key_information(KMIP *, const EncryptionKeyInformation *);
 int kmip_encode_mac_signature_key_information(KMIP *, const MACSignatureKeyInformation *);
@@ -1457,6 +1492,7 @@ int kmip_decode_protocol_version(KMIP *, ProtocolVersion *);
 int kmip_decode_transparent_symmetric_key(KMIP *, TransparentSymmetricKey *);
 int kmip_decode_key_material(KMIP *, enum key_format_type, void **);
 int kmip_decode_key_value(KMIP *, enum key_format_type, KeyValue *);
+int kmip_decode_protection_storage_masks(KMIP *, ProtectionStorageMasks *);
 int kmip_decode_cryptographic_parameters(KMIP *, CryptographicParameters *);
 int kmip_decode_encryption_key_information(KMIP *, EncryptionKeyInformation *);
 int kmip_decode_mac_signature_key_information(KMIP *, MACSignatureKeyInformation *);

--- a/tests.c
+++ b/tests.c
@@ -872,6 +872,302 @@ test_is_attribute_tag(TestTracker *tracker)
 }
 
 int
+test_get_enum_string_index(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    if(kmip_get_enum_string_index(KMIP_TAG_ATTESTATION_TYPE) != 0)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_BATCH_ERROR_CONTINUATION_OPTION) != 1)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_BLOCK_CIPHER_MODE) != 2)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_CREDENTIAL_TYPE) != 3)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_CRYPTOGRAPHIC_ALGORITHM) != 4)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_CRYPTOGRAPHIC_USAGE_MASK) != 5)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_DIGITAL_SIGNATURE_ALGORITHM) != 6)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_ENCODING_OPTION) != 7)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_HASHING_ALGORITHM) != 8)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_KEY_COMPRESSION_TYPE) != 9)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_KEY_FORMAT_TYPE) != 10)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_KEY_ROLE_TYPE) != 11)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_KEY_WRAP_TYPE) != 12)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_MASK_GENERATOR) != 13)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_NAME_TYPE) != 14)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_OBJECT_TYPE) != 15)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_OPERATION) != 16)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_PADDING_METHOD) != 17)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_PROTECTION_STORAGE_MASK) != 18)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_RESULT_REASON) != 19)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_RESULT_STATUS) != 20)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_STATE) != 21)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_TAG) != 22)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_TYPE) != 23)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(KMIP_TAG_WRAPPING_METHOD) != 24)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_get_enum_string_index(-1) != 25)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    TEST_PASSED(tracker, __func__);
+}
+
+int
+test_check_enum_value_protection_storage_masks(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    enum kmip_version v = KMIP_2_0;
+    enum tag t = KMIP_TAG_PROTECTION_STORAGE_MASK;
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_SOFTWARE) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_HARDWARE) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_ON_PROCESSOR) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_ON_SYSTEM) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OFF_SYSTEM) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_HYPERVISOR) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OPERATING_SYSTEM) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_CONTAINER) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_ON_PREMISES) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OFF_PREMISES) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_SELF_MANAGED) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OUTSOURCED) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_VALIDATED) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_SAME_JURISDICTION) != KMIP_OK)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    v = KMIP_1_4;
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_SOFTWARE) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_HARDWARE) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_ON_PROCESSOR) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_ON_SYSTEM) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OFF_SYSTEM) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_HYPERVISOR) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OPERATING_SYSTEM) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_CONTAINER) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_ON_PREMISES) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OFF_PREMISES) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_SELF_MANAGED) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_OUTSOURCED) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_VALIDATED) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, KMIP_PROTECT_SAME_JURISDICTION) != KMIP_INVALID_FOR_VERSION)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    if(kmip_check_enum_value(v, t, -1) != KMIP_ENUM_MISMATCH)
+    {
+        TEST_FAILED(tracker, __func__, __LINE__);
+    }
+
+    TEST_PASSED(tracker, __func__);
+}
+
+int
 test_print_attributes(TestTracker *tracker)
 {
     TRACK_TEST(tracker);
@@ -1509,6 +1805,135 @@ test_decode_name(TestTracker *tracker)
         __func__);
     kmip_free_name(&ctx, &observed);
     kmip_destroy(&ctx);
+    return(result);
+}
+
+int
+test_encode_protection_storage_masks(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following set of values:
+    *  Protection Storage Masks
+    *      Protection Storage Mask
+    *          Software
+    *          Hardware
+    *          On Processor
+    *          On System
+    *          Off System
+    *          Hypervisor
+    *          Operating System
+    *          Container
+    *          On Premises
+    *          Off Premises
+    *          Self Managed
+    *          Outsourced
+    *          Validated
+    *          Same Jurisdiction
+    *      Protection Storage Mask
+    *          Software
+    *          Hardware
+    */
+    uint8 expected[40] = {
+        0x42, 0x01, 0x5F, 0x01, 0x00, 0x00, 0x00, 0x20,
+        0x42, 0x01, 0x5E, 0x02, 0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x3F, 0xFF, 0x00, 0x00, 0x00, 0x00,
+        0x42, 0x01, 0x5E, 0x02, 0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00
+    };
+
+    uint8 observed[40] = {0};
+    KMIP ctx = {0};
+    kmip_init(&ctx, observed, ARRAY_LENGTH(observed), KMIP_2_0);
+
+    LinkedList list = {0};
+    LinkedListItem item_1 = {0};
+    int32 mask_1 = 0x3FFF;
+    item_1.data = &mask_1;
+
+    LinkedListItem item_2 = {0};
+    int32 mask_2 = 0x0003;
+    item_2.data = &mask_2;
+
+    kmip_linked_list_enqueue(&list, &item_1);
+    kmip_linked_list_enqueue(&list, &item_2);
+
+    ProtectionStorageMasks psm = {0};
+    psm.masks = &list;
+
+    int result = kmip_encode_protection_storage_masks(&ctx, &psm);
+    result = report_encoding_test_result(tracker, &ctx, expected, observed, result, __func__);
+
+    kmip_destroy(&ctx);
+
+    return(result);
+}
+
+int
+test_decode_protection_storage_masks(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following set of values:
+    *  Protection Storage Masks
+    *      Protection Storage Mask
+    *          Software
+    *          Hardware
+    *          On Processor
+    *          On System
+    *          Off System
+    *          Hypervisor
+    *          Operating System
+    *          Container
+    *          On Premises
+    *          Off Premises
+    *          Self Managed
+    *          Outsourced
+    *          Validated
+    *          Same Jurisdiction
+    *      Protection Storage Mask
+    *          Software
+    *          Hardware
+    */
+    uint8 encoding[40] = {
+        0x42, 0x01, 0x5F, 0x01, 0x00, 0x00, 0x00, 0x20,
+        0x42, 0x01, 0x5E, 0x02, 0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x3F, 0xFF, 0x00, 0x00, 0x00, 0x00,
+        0x42, 0x01, 0x5E, 0x02, 0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00
+    };
+
+    KMIP ctx = {0};
+    kmip_init(&ctx, encoding, ARRAY_LENGTH(encoding), KMIP_2_0);
+
+    LinkedList list = {0};
+    LinkedListItem item_1 = {0};
+    int32 mask_1 = 0x3FFF;
+    item_1.data = &mask_1;
+
+    LinkedListItem item_2 = {0};
+    int32 mask_2 = 0x0003;
+    item_2.data = &mask_2;
+
+    kmip_linked_list_enqueue(&list, &item_1);
+    kmip_linked_list_enqueue(&list, &item_2);
+
+    ProtectionStorageMasks expected = {0};
+    expected.masks = &list;
+
+    ProtectionStorageMasks observed = {0};
+    int result = kmip_decode_protection_storage_masks(&ctx, &observed);
+    int comparison = kmip_compare_protection_storage_masks(&expected, &observed);
+    if(!comparison)
+    {
+        kmip_print_protection_storage_masks(1, &expected);
+        kmip_print_protection_storage_masks(1, &observed);
+    }
+    result = report_decoding_test_result(tracker, &ctx, comparison, result, __func__);
+
+    kmip_free_protection_storage_masks(&ctx, &observed);
+    kmip_destroy(&ctx);
+
     return(result);
 }
 
@@ -9347,6 +9772,8 @@ run_tests(void)
     test_buffer_bytes_left(&tracker);
     test_peek_tag(&tracker);
     test_is_attribute_tag(&tracker);
+    test_get_enum_string_index(&tracker);
+    test_check_enum_value_protection_storage_masks(&tracker);
 
     printf("\nKMIP 1.0 Feature Tests\n");
     printf("----------------------\n");
@@ -9511,6 +9938,7 @@ run_tests(void)
     
     printf("\nKMIP 2.0 Feature Tests\n");
     printf("----------------------\n");
+    test_decode_protection_storage_masks(&tracker);
     test_decode_attributes(&tracker);
     test_decode_attributes_with_invalid_kmip_version(&tracker);
     test_decode_attribute_v2_unique_identifier(&tracker);
@@ -9523,6 +9951,7 @@ run_tests(void)
     test_decode_attribute_v2_unsupported_attribute(&tracker);
 
     printf("\n");
+    test_encode_protection_storage_masks(&tracker);
     test_encode_attributes(&tracker);
     test_encode_attributes_with_invalid_kmip_version(&tracker);
     test_encode_attribute_v2_unique_identifier(&tracker);


### PR DESCRIPTION
This change adds support for ProtectionStorageMasks, a new mask enumeration added in KMIP 2.0. The mask values designate different methods of protecting stored data on a KMIP server. Along with the new enumerations, this change also includes a wrapping structure that contains a list of arbitrary mask values for use by various operations. Utility functions are included for printing, freeing, comparing, and encoding/decoding this structure. Unit tests have also been added to cover these additions.