### PR TITLE
Update the Create payloads to support KMIP 2.0

### DIFF
--- a/kmip.h
+++ b/kmip.h
@@ -903,12 +903,17 @@ typedef struct nonce
 
 typedef struct create_request_payload
 {
+    /* KMIP 1.0 */
     enum object_type object_type;
     TemplateAttribute *template_attribute;
+    /* KMIP 2.0 */
+    Attributes *attributes;
+    ProtectionStorageMasks *protection_storage_masks;
 } CreateRequestPayload;
 
 typedef struct create_response_payload
 {
+    /* KMIP 1.0 */
     enum object_type object_type;
     TextString *unique_identifier;
     TemplateAttribute *template_attribute;
@@ -1087,6 +1092,13 @@ do                                                      \
     }                                                   \
 } while(0)
 
+#define HANDLE_FAILURE(A, B)                        \
+do                                                  \
+{                                                   \
+    kmip_push_error_frame((A), __func__, __LINE__); \
+    return((B));                                    \
+} while(0)
+
 #define TAG_TYPE(A, B) (((A) << 8) | (uint8)(B))
 
 #define CHECK_TAG_TYPE(A, B, C, D)                      \
@@ -1155,6 +1167,14 @@ do                                                      \
         kmip_push_error_frame((A), __func__, __LINE__); \
         return(KMIP_MEMORY_ALLOC_FAILED);               \
     }                                                   \
+} while(0)
+
+#define HANDLE_FAILED_ALLOC(A, B, C)                \
+do                                                  \
+{                                                   \
+    kmip_set_alloc_error_message((A), (B), (C));    \
+    kmip_push_error_frame((A), __func__, __LINE__); \
+    return(KMIP_MEMORY_ALLOC_FAILED);               \
 } while(0)
 
 #define CHECK_ENCODE_ARGS(A, B)   \


### PR DESCRIPTION
This change updates the Create request and response payloads to support changes introduced in KMIP 2.0, including the addition of the new KMIP 2.0-style attributes and support for protection storage masks. The encoding and decoding functions for these payloads have been updated to use the new fields. Utility functions for these payloads, including comparing, printing, and freeing them have also been updated. Unit tests have been added to test the new functionality.