### PR TITLE
Update the RequestBatchItem to support the Ephemeral field

### DIFF
--- a/demo_create.c
+++ b/demo_create.c
@@ -209,6 +209,7 @@ use_low_level_api(const char *server_address,
     crp.template_attribute = &ta;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_CREATE;
     rbi.request_payload = &crp;
     

--- a/kmip.h
+++ b/kmip.h
@@ -653,6 +653,7 @@ enum tag
     KMIP_TAG_SERVER_CORRELATION_VALUE         = 0x420106,
     /* KMIP 2.0 */
     KMIP_TAG_ATTRIBUTES                       = 0x420125,
+    KMIP_TAG_EPHEMERAL                        = 0x420154,
     KMIP_TAG_PROTECTION_STORAGE_MASK          = 0x42015E,
     KMIP_TAG_PROTECTION_STORAGE_MASKS         = 0x42015F,
     KMIP_TAG_COMMON_PROTECTION_STORAGE_MASKS  = 0x420163,
@@ -1028,9 +1029,12 @@ typedef struct response_header
 
 typedef struct request_batch_item
 {
+    /* KMIP 1.0 */
     enum operation operation;
     ByteString *unique_batch_item_id;
     void *request_payload;
+    /* KMIP 2.0 */
+    bool32 ephemeral;
     /* NOTE (ph) Omitting the message extension field for now. */
 } RequestBatchItem;
 
@@ -1268,6 +1272,7 @@ void kmip_init_cryptographic_parameters(CryptographicParameters *);
 void kmip_init_key_block(KeyBlock *);
 void kmip_init_request_header(RequestHeader *);
 void kmip_init_response_header(ResponseHeader *);
+void kmip_init_request_batch_item(RequestBatchItem *);
 
 /*
 Printing Functions

--- a/kmip_bio.c
+++ b/kmip_bio.c
@@ -70,6 +70,7 @@ int kmip_bio_create_symmetric_key(BIO *bio,
     crp.template_attribute = template_attribute;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_CREATE;
     rbi.request_payload = &crp;
     
@@ -279,6 +280,7 @@ int kmip_bio_destroy_symmetric_key(BIO *bio, char *uuid, int uuid_size)
     drp.unique_identifier = &id;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_DESTROY;
     rbi.request_payload = &drp;
     
@@ -482,6 +484,7 @@ int kmip_bio_get_symmetric_key(BIO *bio,
     grp.unique_identifier = &uuid;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_GET;
     rbi.request_payload = &grp;
     
@@ -712,6 +715,7 @@ int kmip_bio_create_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     crp.template_attribute = template_attribute;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_CREATE;
     rbi.request_payload = &crp;
     
@@ -927,6 +931,7 @@ int kmip_bio_get_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     grp.unique_identifier = &id;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_GET;
     rbi.request_payload = &grp;
     
@@ -1164,6 +1169,7 @@ int kmip_bio_destroy_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     drp.unique_identifier = &id;
     
     RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
     rbi.operation = KMIP_OP_DESTROY;
     rbi.request_payload = &drp;
     


### PR DESCRIPTION
This change updates the RequestBatchItem to add support for the new Ephemeral field introduced in KMIP 2.0. A new initializer is included to properly set the RequestBatchItem fields and all related RequestBatchItem functions have been updated to handle the Ephemeral field properly. Unit tests have been added to cover these changes.