### PR TITLE
Extend gitignore to ignore binaries created during compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.o
-
+*.a
+*.lo
+*.so*
+demo_create
+demo_get
+demo_destroy
+tests


### PR DESCRIPTION
This change extends gitignore list by binaries produced during
compliation process. It is to avoid git claiming to potentially stage
this files for commit.

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@intel.com>