### PR TITLE
Add support for the Deactivation Date attribute

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -2815,6 +2815,11 @@ kmip_print_attribute_type_enum(FILE *f, enum attribute_type value)
         {
             fprintf(f, "Activation Date");
         } break;
+
+        case KMIP_ATTR_DEACTIVATION_DATE:
+        {
+            fprintf(f, "Deactivation Date");
+        } break;
         
         default:
         fprintf(f, "Unknown");
@@ -4021,6 +4026,12 @@ kmip_print_attribute_value(FILE *f, int indent, enum attribute_type type, void *
             fprintf(f, "\n");
             kmip_print_date_time(f, *(int64 *)value);
         } break;
+
+        case KMIP_ATTR_DEACTIVATION_DATE:
+        {
+            fprintf(f, "\n");
+            kmip_print_date_time(f, *(int64 *)value);
+        } break;
         
         default:
         fprintf(f, "Unknown\n");
@@ -4755,6 +4766,7 @@ kmip_free_attribute(KMIP *ctx, Attribute *value)
                 break;
 
                 case KMIP_ATTR_ACTIVATION_DATE:
+                case KMIP_ATTR_DEACTIVATION_DATE:
                 {
                     *(int64*)value->value = KMIP_UNSET;
                 } break;
@@ -6031,6 +6043,7 @@ kmip_deep_copy_attribute(KMIP *ctx, const Attribute *value)
         } break;
 
         case KMIP_ATTR_ACTIVATION_DATE:
+        case KMIP_ATTR_DEACTIVATION_DATE:
         {
             copy->value = kmip_deep_copy_int64(ctx, (int64 *)value->value);
             if(copy->value == NULL)
@@ -6300,6 +6313,7 @@ kmip_compare_attribute(const Attribute *a, const Attribute *b)
                 break;
 
                 case KMIP_ATTR_ACTIVATION_DATE:
+                case KMIP_ATTR_DEACTIVATION_DATE:
                 {
                     if(*(int64*)a->value != *(int64*)b->value)
                     {
@@ -8524,6 +8538,12 @@ kmip_encode_attribute_name(KMIP *ctx, enum attribute_type value)
             attribute_name.value = "Activation Date";
             attribute_name.size = 15;
         } break;
+
+        case KMIP_ATTR_DEACTIVATION_DATE:
+        {
+            attribute_name.value = "Deactivation Date";
+            attribute_name.size = 17;
+        } break;
         
         default:
         kmip_push_error_frame(ctx, __func__, __LINE__);
@@ -8628,6 +8648,7 @@ kmip_encode_attribute_v1(KMIP *ctx, const Attribute *value)
         break;
 
         case KMIP_ATTR_ACTIVATION_DATE:
+        case KMIP_ATTR_DEACTIVATION_DATE:
         {
             result = kmip_encode_date_time(ctx, t, *(int64 *)value->value);
         } break;
@@ -8760,6 +8781,15 @@ kmip_encode_attribute_v2(KMIP *ctx, const Attribute *value)
             result = kmip_encode_date_time(
                 ctx,
                 KMIP_TAG_ACTIVATION_DATE,
+                *(int64 *)value->value
+            );
+        } break;
+
+        case KMIP_ATTR_DEACTIVATION_DATE:
+        {
+            result = kmip_encode_date_time(
+                ctx,
+                KMIP_TAG_DEACTIVATION_DATE,
                 *(int64 *)value->value
             );
         } break;
@@ -10671,6 +10701,10 @@ kmip_decode_attribute_name(KMIP *ctx, enum attribute_type *value)
     {
         *value = KMIP_ATTR_ACTIVATION_DATE;
     }
+    else if((n.size == 17) && (strncmp(n.value, "Deactivation Date", 17) == 0))
+    {
+        *value = KMIP_ATTR_DEACTIVATION_DATE;
+    }
     /* TODO (ph) Add all remaining attributes here. */
     else
     {
@@ -10889,6 +10923,15 @@ kmip_decode_attribute_v1(KMIP *ctx, Attribute *value)
             CHECK_RESULT(ctx, result);
         } break;
 
+        case KMIP_ATTR_DEACTIVATION_DATE:
+        {
+            value->value = ctx->calloc_func(ctx->state, 1, sizeof(int64));
+            CHECK_NEW_MEMORY(ctx, value->value, sizeof(int64), "DeactivationDate date time");
+
+            result = kmip_decode_date_time(ctx, t, (int64*)value->value);
+            CHECK_RESULT(ctx, result);
+        } break;
+
         default:
         kmip_push_error_frame(ctx, __func__, __LINE__);
         return(KMIP_ERROR_ATTR_UNSUPPORTED);
@@ -11030,6 +11073,16 @@ kmip_decode_attribute_v2(KMIP *ctx, Attribute *value)
             CHECK_NEW_MEMORY(ctx, value->value, sizeof(int64), "ActivationDate date time");
 
             result = kmip_decode_date_time(ctx, KMIP_TAG_ACTIVATION_DATE, (int64*)value->value);
+            CHECK_RESULT(ctx, result);
+        } break;
+
+        case KMIP_TAG_DEACTIVATION_DATE:
+        {
+            value->type = KMIP_ATTR_DEACTIVATION_DATE;
+            value->value = ctx->calloc_func(ctx->state, 1, sizeof(int64));
+            CHECK_NEW_MEMORY(ctx, value->value, sizeof(int64), "DeactivationDate date time");
+
+            result = kmip_decode_date_time(ctx, KMIP_TAG_DEACTIVATION_DATE, (int64*)value->value);
             CHECK_RESULT(ctx, result);
         } break;
 

--- a/kmip.h
+++ b/kmip.h
@@ -84,7 +84,8 @@ enum attribute_type
     KMIP_ATTR_STATE                            = 7,
     KMIP_ATTR_APPLICATION_SPECIFIC_INFORMATION = 8,
     KMIP_ATTR_OBJECT_GROUP                     = 9,
-    KMIP_ATTR_ACTIVATION_DATE                  = 10
+    KMIP_ATTR_ACTIVATION_DATE                  = 10,
+    KMIP_ATTR_DEACTIVATION_DATE                = 11
 };
 
 enum batch_error_continuation_option
@@ -575,6 +576,7 @@ enum tag
     KMIP_TAG_CRYPTOGRAPHIC_LENGTH             = 0x42002A,
     KMIP_TAG_CRYPTOGRAPHIC_PARAMETERS         = 0x42002B,
     KMIP_TAG_CRYPTOGRAPHIC_USAGE_MASK         = 0x42002C,
+    KMIP_TAG_DEACTIVATION_DATE                = 0x42002F,
     KMIP_TAG_ENCRYPTION_KEY_INFORMATION       = 0x420036,
     KMIP_TAG_HASHING_ALGORITHM                = 0x420038,
     KMIP_TAG_IV_COUNTER_NONCE                 = 0x42003D,

--- a/tests.c
+++ b/tests.c
@@ -3494,6 +3494,94 @@ test_decode_attribute_activation_date(TestTracker *tracker)
 }
 
 int
+test_encode_attribute_deactivation_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Attribute
+    *      Attribute Name - Deactivation Date
+    *      Attribute Value - 1335514467 (Fri Apr 27 10:14:27 CEST 2012)
+    */
+    uint8 expected[56] = {
+        0x42, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00, 0x30,
+        0x42, 0x00, 0x0A, 0x07, 0x00, 0x00, 0x00, 0x11,
+        0x44, 0x65, 0x61, 0x63, 0x74, 0x69, 0x76, 0x61,
+        0x74, 0x69, 0x6F, 0x6E, 0x20, 0x44, 0x61, 0x74,
+        0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x42, 0x00, 0x0B, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x55, 0x63
+    };
+
+    uint8 observed[56] = {0};
+    KMIP ctx = {0};
+    kmip_init(&ctx, observed, ARRAY_LENGTH(observed), KMIP_1_0);
+
+    int64 date_time = 1335514467;
+
+    Attribute attr = {0};
+    kmip_init_attribute(&attr);
+
+    attr.type = KMIP_ATTR_DEACTIVATION_DATE;
+    attr.value = &date_time;
+
+    int result = kmip_encode_attribute(&ctx, &attr);
+    result = report_encoding_test_result(
+        tracker,
+        &ctx,
+        expected,
+        observed,
+        result,
+        __func__
+    );
+    kmip_destroy(&ctx);
+    return(result);
+}
+
+int
+test_decode_attribute_deactivation_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Attribute
+    *      Attribute Name - Deactivation Date
+    *      Attribute Value - 1335514467 (Fri Apr 27 10:14:27 CEST 2012)
+    */
+    uint8 encoding[56] = {
+        0x42, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00, 0x30,
+        0x42, 0x00, 0x0A, 0x07, 0x00, 0x00, 0x00, 0x11,
+        0x44, 0x65, 0x61, 0x63, 0x74, 0x69, 0x76, 0x61,
+        0x74, 0x69, 0x6F, 0x6E, 0x20, 0x44, 0x61, 0x74,
+        0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x42, 0x00, 0x0B, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x55, 0x63
+    };
+
+    KMIP ctx = {0};
+    kmip_init(&ctx, encoding, ARRAY_LENGTH(encoding), KMIP_1_0);
+
+    int64 date_time = 1335514467;
+    Attribute expected = {0};
+    kmip_init_attribute(&expected);
+    expected.type = KMIP_ATTR_DEACTIVATION_DATE;
+    expected.value = &date_time;
+    Attribute observed = {0};
+    kmip_init_attribute(&observed);
+
+    int result = kmip_decode_attribute(&ctx, &observed);
+    result = report_decoding_test_result(
+        tracker,
+        &ctx,
+        kmip_compare_attribute(&expected, &observed),
+        result,
+        __func__);
+    kmip_free_attribute(&ctx, &observed);
+    kmip_destroy(&ctx);
+    return(result);
+}
+
+int
 test_encode_protocol_version(TestTracker *tracker)
 {
     TRACK_TEST(tracker);
@@ -8543,6 +8631,39 @@ test_encode_attribute_v2_activation_date(TestTracker *tracker)
 }
 
 int
+test_encode_attribute_v2_deactivation_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Deactivation Date - 1335514467 (Fri Apr 27 10:14:27 CEST 2012)
+    */
+    uint8 expected[16] = {
+        0x42, 0x00, 0x2F, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x55, 0x63
+    };
+
+    uint8 observed[16] = {0};
+    KMIP ctx = {0};
+    kmip_init(&ctx, observed, ARRAY_LENGTH(observed), KMIP_2_0);
+
+    int64 date_time = 1335514467;
+
+    Attribute attribute = {0};
+    kmip_init_attribute(&attribute);
+
+    attribute.type = KMIP_ATTR_DEACTIVATION_DATE;
+    attribute.value = &date_time;
+
+    int result = kmip_encode_attribute_v2(&ctx, &attribute);
+    result = report_encoding_test_result(tracker, &ctx, expected, observed, result, __func__);
+
+    kmip_destroy(&ctx);
+
+    return(result);
+}
+
+int
 test_encode_attribute_v2_unsupported_attribute(TestTracker *tracker)
 {
     TRACK_TEST(tracker);
@@ -9100,6 +9221,46 @@ test_decode_attribute_v2_activation_date(TestTracker *tracker)
     kmip_init_attribute(&expected);
 
     expected.type = KMIP_ATTR_ACTIVATION_DATE;
+    expected.value = &date_time;
+
+    Attribute observed = {0};
+    int result = kmip_decode_attribute_v2(&ctx, &observed);
+    int comparison = kmip_compare_attribute(&expected, &observed);
+    if(!comparison)
+    {
+        kmip_print_attribute(stderr, 1, &expected);
+        kmip_print_attribute(stderr, 1, &observed);
+    }
+    result = report_decoding_test_result(tracker, &ctx, comparison, result, __func__);
+
+    kmip_free_attribute(&ctx, &observed);
+    kmip_destroy(&ctx);
+
+    return(result);
+}
+
+int
+test_decode_attribute_v2_deactivation_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Deactivation Date - 1335514467 (Fri Apr 27 10:14:27 CEST 2012)
+    */
+    uint8 encoding[16] = {
+        0x42, 0x00, 0x2F, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x55, 0x63
+    };
+
+    KMIP ctx = {0};
+    kmip_init(&ctx, encoding, ARRAY_LENGTH(encoding), KMIP_2_0);
+
+    int64 date_time = 1335514467;
+
+    Attribute expected = {0};
+    kmip_init_attribute(&expected);
+
+    expected.type = KMIP_ATTR_DEACTIVATION_DATE;
     expected.value = &date_time;
 
     Attribute observed = {0};
@@ -11667,6 +11828,7 @@ run_tests(void)
     test_decode_attribute_state(&tracker);
     test_decode_attribute_object_group(&tracker);
     test_decode_attribute_activation_date(&tracker);
+    test_decode_attribute_deactivation_date(&tracker);
     test_decode_template_attribute(&tracker);
     test_decode_protocol_version(&tracker);
     test_decode_key_material_byte_string(&tracker);
@@ -11722,6 +11884,7 @@ run_tests(void)
     test_encode_attribute_state(&tracker);
     test_encode_attribute_object_group(&tracker);
     test_encode_attribute_activation_date(&tracker);
+    test_encode_attribute_deactivation_date(&tracker);
     test_encode_protocol_version(&tracker);
     test_encode_cryptographic_parameters(&tracker);
     test_encode_encryption_key_information(&tracker);
@@ -11817,6 +11980,7 @@ run_tests(void)
     test_decode_attribute_v2_state(&tracker);
     test_decode_attribute_v2_object_group(&tracker);
     test_decode_attribute_v2_activation_date(&tracker);
+    test_decode_attribute_v2_deactivation_date(&tracker);
     test_decode_attribute_v2_unsupported_attribute(&tracker);
     test_decode_create_request_payload_kmip_2_0(&tracker);
     test_decode_request_batch_item_get_payload_kmip_2_0(&tracker);
@@ -11837,6 +12001,7 @@ run_tests(void)
     test_encode_attribute_v2_state(&tracker);
     test_encode_attribute_v2_object_group(&tracker);
     test_encode_attribute_v2_activation_date(&tracker);
+    test_encode_attribute_v2_deactivation_date(&tracker);
     test_encode_attribute_v2_unsupported_attribute(&tracker);
     test_encode_create_request_payload_kmip_2_0(&tracker);
     test_encode_request_batch_item_get_payload_kmip_2_0(&tracker);


### PR DESCRIPTION
This change adds support for the Deactivation Date attribute, a KMIP 1.0 date time attribute. All attribute utility functions have been updated to support it along with new test functions.