### PR TITLE
Add support for the Protect Stop Date attribute

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -2825,6 +2825,11 @@ kmip_print_attribute_type_enum(FILE *f, enum attribute_type value)
         {
             fprintf(f, "Process Start Date");
         } break;
+
+        case KMIP_ATTR_PROTECT_STOP_DATE:
+        {
+            fprintf(f, "Protect Stop Date");
+        } break;
         
         default:
         fprintf(f, "Unknown");
@@ -4029,6 +4034,7 @@ kmip_print_attribute_value(FILE *f, int indent, enum attribute_type type, void *
         case KMIP_ATTR_ACTIVATION_DATE:
         case KMIP_ATTR_DEACTIVATION_DATE:
         case KMIP_ATTR_PROCESS_START_DATE:
+        case KMIP_ATTR_PROTECT_STOP_DATE:
         {
             fprintf(f, "\n");
             kmip_print_date_time(f, *(int64 *)value);
@@ -4769,6 +4775,7 @@ kmip_free_attribute(KMIP *ctx, Attribute *value)
                 case KMIP_ATTR_ACTIVATION_DATE:
                 case KMIP_ATTR_DEACTIVATION_DATE:
                 case KMIP_ATTR_PROCESS_START_DATE:
+                case KMIP_ATTR_PROTECT_STOP_DATE:
                 {
                     *(int64*)value->value = KMIP_UNSET;
                 } break;
@@ -6047,6 +6054,7 @@ kmip_deep_copy_attribute(KMIP *ctx, const Attribute *value)
         case KMIP_ATTR_ACTIVATION_DATE:
         case KMIP_ATTR_DEACTIVATION_DATE:
         case KMIP_ATTR_PROCESS_START_DATE:
+        case KMIP_ATTR_PROTECT_STOP_DATE:
         {
             copy->value = kmip_deep_copy_int64(ctx, (int64 *)value->value);
             if(copy->value == NULL)
@@ -6318,6 +6326,7 @@ kmip_compare_attribute(const Attribute *a, const Attribute *b)
                 case KMIP_ATTR_ACTIVATION_DATE:
                 case KMIP_ATTR_DEACTIVATION_DATE:
                 case KMIP_ATTR_PROCESS_START_DATE:
+                case KMIP_ATTR_PROTECT_STOP_DATE:
                 {
                     if(*(int64*)a->value != *(int64*)b->value)
                     {
@@ -8554,6 +8563,12 @@ kmip_encode_attribute_name(KMIP *ctx, enum attribute_type value)
             attribute_name.value = "Process Start Date";
             attribute_name.size = 18;
         } break;
+
+        case KMIP_ATTR_PROTECT_STOP_DATE:
+        {
+            attribute_name.value = "Protect Stop Date";
+            attribute_name.size = 17;
+        } break;
         
         default:
         kmip_push_error_frame(ctx, __func__, __LINE__);
@@ -8660,6 +8675,7 @@ kmip_encode_attribute_v1(KMIP *ctx, const Attribute *value)
         case KMIP_ATTR_ACTIVATION_DATE:
         case KMIP_ATTR_DEACTIVATION_DATE:
         case KMIP_ATTR_PROCESS_START_DATE:
+        case KMIP_ATTR_PROTECT_STOP_DATE:
         {
             result = kmip_encode_date_time(ctx, t, *(int64 *)value->value);
         } break;
@@ -8810,6 +8826,15 @@ kmip_encode_attribute_v2(KMIP *ctx, const Attribute *value)
             result = kmip_encode_date_time(
                 ctx,
                 KMIP_TAG_PROCESS_START_DATE,
+                *(int64 *)value->value
+            );
+        } break;
+
+        case KMIP_ATTR_PROTECT_STOP_DATE:
+        {
+            result = kmip_encode_date_time(
+                ctx,
+                KMIP_TAG_PROTECT_STOP_DATE,
                 *(int64 *)value->value
             );
         } break;
@@ -10729,6 +10754,10 @@ kmip_decode_attribute_name(KMIP *ctx, enum attribute_type *value)
     {
         *value = KMIP_ATTR_PROCESS_START_DATE;
     }
+    else if((17 == n.size) && (strncmp(n.value, "Protect Stop Date", 17) == 0))
+    {
+        *value = KMIP_ATTR_PROTECT_STOP_DATE;
+    }
     /* TODO (ph) Add all remaining attributes here. */
     else
     {
@@ -10965,6 +10994,15 @@ kmip_decode_attribute_v1(KMIP *ctx, Attribute *value)
             CHECK_RESULT(ctx, result);
         } break;
 
+        case KMIP_ATTR_PROTECT_STOP_DATE:
+        {
+            value->value = ctx->calloc_func(ctx->state, 1, sizeof(int64));
+            CHECK_NEW_MEMORY(ctx, value->value, sizeof(int64), "ProtectStopDate date time");
+
+            result = kmip_decode_date_time(ctx, t, (int64*)value->value);
+            CHECK_RESULT(ctx, result);
+        } break;
+
         default:
         kmip_push_error_frame(ctx, __func__, __LINE__);
         return(KMIP_ERROR_ATTR_UNSUPPORTED);
@@ -11124,6 +11162,16 @@ kmip_decode_attribute_v2(KMIP *ctx, Attribute *value)
             value->type = KMIP_ATTR_PROCESS_START_DATE;
             value->value = ctx->calloc_func(ctx->state, 1, sizeof(int64));
             CHECK_NEW_MEMORY(ctx, value->value, sizeof(int64), "ProcessStartDate date time");
+
+            result = kmip_decode_date_time(ctx, tag, (int64*)value->value);
+            CHECK_RESULT(ctx, result);
+        } break;
+
+        case KMIP_TAG_PROTECT_STOP_DATE:
+        {
+            value->type = KMIP_ATTR_PROTECT_STOP_DATE;
+            value->value = ctx->calloc_func(ctx->state, 1, sizeof(int64));
+            CHECK_NEW_MEMORY(ctx, value->value, sizeof(int64), "ProtectStopDate date time");
 
             result = kmip_decode_date_time(ctx, tag, (int64*)value->value);
             CHECK_RESULT(ctx, result);

--- a/kmip.h
+++ b/kmip.h
@@ -86,7 +86,8 @@ enum attribute_type
     KMIP_ATTR_OBJECT_GROUP                     = 9,
     KMIP_ATTR_ACTIVATION_DATE                  = 10,
     KMIP_ATTR_DEACTIVATION_DATE                = 11,
-    KMIP_ATTR_PROCESS_START_DATE               = 12
+    KMIP_ATTR_PROCESS_START_DATE               = 12,
+    KMIP_ATTR_PROTECT_STOP_DATE                = 13
 };
 
 enum batch_error_continuation_option
@@ -602,6 +603,7 @@ enum tag
     KMIP_TAG_PADDING_METHOD                   = 0x42005F,
     KMIP_TAG_PRIVATE_KEY                      = 0x420064,
     KMIP_TAG_PROCESS_START_DATE               = 0x420067,
+    KMIP_TAG_PROTECT_STOP_DATE                = 0x420068,
     KMIP_TAG_PROTOCOL_VERSION                 = 0x420069,
     KMIP_TAG_PROTOCOL_VERSION_MAJOR           = 0x42006A,
     KMIP_TAG_PROTOCOL_VERSION_MINOR           = 0x42006B,

--- a/tests.c
+++ b/tests.c
@@ -3670,6 +3670,94 @@ test_decode_attribute_process_start_date(TestTracker *tracker)
 }
 
 int
+test_encode_attribute_protect_stop_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Attribute
+    *      Attribute Name - Protect Stop Date
+    *      Attribute Value - 1335514945 (Fri Apr 27 10:22:25 CEST 2012)
+    */
+    uint8 expected[56] = {
+        0x42, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00, 0x30,
+        0x42, 0x00, 0x0A, 0x07, 0x00, 0x00, 0x00, 0x11,
+        0x50, 0x72, 0x6F, 0x74, 0x65, 0x63, 0x74, 0x20,
+        0x53, 0x74, 0x6F, 0x70, 0x20, 0x44, 0x61, 0x74,
+        0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x42, 0x00, 0x0B, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x57, 0x41
+    };
+
+    uint8 observed[56] = {0};
+    KMIP ctx = {0};
+    kmip_init(&ctx, observed, ARRAY_LENGTH(observed), KMIP_1_0);
+
+    int64 date_time = 1335514945;
+
+    Attribute attr = {0};
+    kmip_init_attribute(&attr);
+
+    attr.type = KMIP_ATTR_PROTECT_STOP_DATE;
+    attr.value = &date_time;
+
+    int result = kmip_encode_attribute(&ctx, &attr);
+    result = report_encoding_test_result(
+        tracker,
+        &ctx,
+        expected,
+        observed,
+        result,
+        __func__
+    );
+    kmip_destroy(&ctx);
+    return(result);
+}
+
+int
+test_decode_attribute_protect_stop_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Attribute
+    *      Attribute Name - Protect Stop Date
+    *      Attribute Value - 1335514945 (Fri Apr 27 10:22:25 CEST 2012)
+    */
+    uint8 encoding[56] = {
+        0x42, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00, 0x30,
+        0x42, 0x00, 0x0A, 0x07, 0x00, 0x00, 0x00, 0x11,
+        0x50, 0x72, 0x6F, 0x74, 0x65, 0x63, 0x74, 0x20,
+        0x53, 0x74, 0x6F, 0x70, 0x20, 0x44, 0x61, 0x74,
+        0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x42, 0x00, 0x0B, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x57, 0x41
+    };
+
+    KMIP ctx = {0};
+    kmip_init(&ctx, encoding, ARRAY_LENGTH(encoding), KMIP_1_0);
+
+    int64 date_time = 1335514945;
+    Attribute expected = {0};
+    kmip_init_attribute(&expected);
+    expected.type = KMIP_ATTR_PROTECT_STOP_DATE;
+    expected.value = &date_time;
+    Attribute observed = {0};
+    kmip_init_attribute(&observed);
+
+    int result = kmip_decode_attribute(&ctx, &observed);
+    result = report_decoding_test_result(
+        tracker,
+        &ctx,
+        kmip_compare_attribute(&expected, &observed),
+        result,
+        __func__);
+    kmip_free_attribute(&ctx, &observed);
+    kmip_destroy(&ctx);
+    return(result);
+}
+
+int
 test_encode_protocol_version(TestTracker *tracker)
 {
     TRACK_TEST(tracker);
@@ -8785,6 +8873,39 @@ test_encode_attribute_v2_process_start_date(TestTracker *tracker)
 }
 
 int
+test_encode_attribute_v2_protect_stop_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Protect Stop Date - 1335514945 (Fri Apr 27 10:22:25 CEST 2012)
+    */
+    uint8 expected[16] = {
+        0x42, 0x00, 0x68, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x57, 0x41
+    };
+
+    uint8 observed[16] = {0};
+    KMIP ctx = {0};
+    kmip_init(&ctx, observed, ARRAY_LENGTH(observed), KMIP_2_0);
+
+    int64 date_time = 1335514945;
+
+    Attribute attribute = {0};
+    kmip_init_attribute(&attribute);
+
+    attribute.type = KMIP_ATTR_PROTECT_STOP_DATE;
+    attribute.value = &date_time;
+
+    int result = kmip_encode_attribute_v2(&ctx, &attribute);
+    result = report_encoding_test_result(tracker, &ctx, expected, observed, result, __func__);
+
+    kmip_destroy(&ctx);
+
+    return(result);
+}
+
+int
 test_encode_attribute_v2_unsupported_attribute(TestTracker *tracker)
 {
     TRACK_TEST(tracker);
@@ -9422,6 +9543,46 @@ test_decode_attribute_v2_process_start_date(TestTracker *tracker)
     kmip_init_attribute(&expected);
 
     expected.type = KMIP_ATTR_PROCESS_START_DATE;
+    expected.value = &date_time;
+
+    Attribute observed = {0};
+    int result = kmip_decode_attribute_v2(&ctx, &observed);
+    int comparison = kmip_compare_attribute(&expected, &observed);
+    if(!comparison)
+    {
+        kmip_print_attribute(stderr, 1, &expected);
+        kmip_print_attribute(stderr, 1, &observed);
+    }
+    result = report_decoding_test_result(tracker, &ctx, comparison, result, __func__);
+
+    kmip_free_attribute(&ctx, &observed);
+    kmip_destroy(&ctx);
+
+    return(result);
+}
+
+int
+test_decode_attribute_v2_protect_stop_date(TestTracker *tracker)
+{
+    TRACK_TEST(tracker);
+
+    /* This encoding matches the following values:
+    *  Protect Stop Date - 1335514945 (Fri Apr 27 10:22:25 CEST 2012)
+    */
+    uint8 encoding[16] = {
+        0x42, 0x00, 0x68, 0x09, 0x00, 0x00, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x4F, 0x9A, 0x57, 0x41
+    };
+
+    KMIP ctx = {0};
+    kmip_init(&ctx, encoding, ARRAY_LENGTH(encoding), KMIP_2_0);
+
+    int64 date_time = 1335514945;
+
+    Attribute expected = {0};
+    kmip_init_attribute(&expected);
+
+    expected.type = KMIP_ATTR_PROTECT_STOP_DATE;
     expected.value = &date_time;
 
     Attribute observed = {0};
@@ -11991,6 +12152,7 @@ run_tests(void)
     test_decode_attribute_activation_date(&tracker);
     test_decode_attribute_deactivation_date(&tracker);
     test_decode_attribute_process_start_date(&tracker);
+    test_decode_attribute_protect_stop_date(&tracker);
     test_decode_template_attribute(&tracker);
     test_decode_protocol_version(&tracker);
     test_decode_key_material_byte_string(&tracker);
@@ -12048,6 +12210,7 @@ run_tests(void)
     test_encode_attribute_activation_date(&tracker);
     test_encode_attribute_deactivation_date(&tracker);
     test_encode_attribute_process_start_date(&tracker);
+    test_encode_attribute_protect_stop_date(&tracker);
     test_encode_protocol_version(&tracker);
     test_encode_cryptographic_parameters(&tracker);
     test_encode_encryption_key_information(&tracker);
@@ -12145,6 +12308,7 @@ run_tests(void)
     test_decode_attribute_v2_activation_date(&tracker);
     test_decode_attribute_v2_deactivation_date(&tracker);
     test_decode_attribute_v2_process_start_date(&tracker);
+    test_decode_attribute_v2_protect_stop_date(&tracker);
     test_decode_attribute_v2_unsupported_attribute(&tracker);
     test_decode_create_request_payload_kmip_2_0(&tracker);
     test_decode_request_batch_item_get_payload_kmip_2_0(&tracker);
@@ -12167,6 +12331,7 @@ run_tests(void)
     test_encode_attribute_v2_activation_date(&tracker);
     test_encode_attribute_v2_deactivation_date(&tracker);
     test_encode_attribute_v2_process_start_date(&tracker);
+    test_encode_attribute_v2_protect_stop_date(&tracker);
     test_encode_attribute_v2_unsupported_attribute(&tracker);
     test_encode_create_request_payload_kmip_2_0(&tracker);
     test_encode_request_batch_item_get_payload_kmip_2_0(&tracker);


### PR DESCRIPTION
This change adds support for the Protect Stop Date attribute, a KMIP 1.0 date time attribute. All attribute utility functions have been updated to support it along with new test functions.