### PR TITLE
Fix cases of unread but assigned values

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -1410,7 +1410,7 @@ kmip_is_tag_next(const KMIP *ctx, enum tag t)
     
     tag |= ((uint32)*index++ << 16);
     tag |= ((uint32)*index++ << 8);
-    tag |= ((uint32)*index++ << 0);
+    tag |= ((uint32)*index   << 0);
     
     if(tag != t)
     {
@@ -1440,7 +1440,7 @@ kmip_is_tag_type_next(const KMIP *ctx, enum tag t, enum type s)
     tag_type |= ((uint32)*index++ << 24);
     tag_type |= ((uint32)*index++ << 16);
     tag_type |= ((uint32)*index++ << 8);
-    tag_type |= ((uint32)*index++ << 0);
+    tag_type |= ((uint32)*index   << 0);
     
     if(tag_type != TAG_TYPE(t, s))
     {
@@ -1509,7 +1509,7 @@ kmip_peek_tag(KMIP *ctx)
 
     tag |= ((int32)*index++ << 16);
     tag |= ((int32)*index++ << 8);
-    tag |= ((int32)*index++ << 0);
+    tag |= ((int32)*index   << 0);
 
     return(tag);
 }
@@ -8730,7 +8730,7 @@ kmip_encode_attribute_v1(KMIP *ctx, const Attribute *value)
         CHECK_RESULT(ctx, result);
     }
     
-    uint8 *curr_index = ctx->index;
+    uint8 *curr_index = 0;
     uint8 *tag_index = ctx->index;
     enum tag t = KMIP_TAG_ATTRIBUTE_VALUE;
     
@@ -10986,7 +10986,7 @@ kmip_decode_attribute_v1(KMIP *ctx, Attribute *value)
         CHECK_RESULT(ctx, result);
     }
     
-    uint8 *curr_index = ctx->index;
+    uint8 *curr_index = 0;
     uint8 *tag_index = ctx->index;
     enum tag t = KMIP_TAG_ATTRIBUTE_VALUE;
     

--- a/kmip_bio.c
+++ b/kmip_bio.c
@@ -184,8 +184,7 @@ int kmip_bio_create_symmetric_key(BIO *bio,
         kmip_destroy(&ctx);
         return(decode_result);
     }
-    
-    enum result_status result = KMIP_STATUS_OPERATION_FAILED;
+
     if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
     {
         kmip_free_response_message(&ctx, &resp_m);
@@ -196,7 +195,7 @@ int kmip_bio_create_symmetric_key(BIO *bio,
     }
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
-    result = resp_item.result_status;
+    enum result_status result = resp_item.result_status;
 
     if(result != KMIP_STATUS_SUCCESS)
     {
@@ -413,8 +412,7 @@ int kmip_bio_destroy_symmetric_key(BIO *bio, char *uuid, int uuid_size)
         kmip_destroy(&ctx);
         return(decode_result);
     }
-    
-    enum result_status result = KMIP_STATUS_OPERATION_FAILED;
+
     if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
     {
         kmip_free_response_message(&ctx, &resp_m);
@@ -425,7 +423,7 @@ int kmip_bio_destroy_symmetric_key(BIO *bio, char *uuid, int uuid_size)
     }
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
-    result = resp_item.result_status;
+    enum result_status result = resp_item.result_status;
     
     /* Clean up the response message, the encoding buffer, and the KMIP */
     /* context. */
@@ -613,8 +611,7 @@ int kmip_bio_get_symmetric_key(BIO *bio,
     
     kmip_free_buffer(&ctx, encoding, buffer_total_size);
     encoding = NULL;
-    
-    enum result_status result = KMIP_STATUS_OPERATION_FAILED;
+
     if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
     {
         kmip_free_response_message(&ctx, &resp_m);
@@ -624,7 +621,7 @@ int kmip_bio_get_symmetric_key(BIO *bio,
     }
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
-    result = resp_item.result_status;
+    enum result_status result = resp_item.result_status;
     
     if(result != KMIP_STATUS_SUCCESS)
     {
@@ -851,8 +848,7 @@ int kmip_bio_create_symmetric_key_with_context(KMIP *ctx, BIO *bio,
         encoding = NULL;
         return(decode_result);
     }
-    
-    enum result_status result = KMIP_STATUS_OPERATION_FAILED;
+
     if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
     {
         kmip_free_response_message(ctx, &resp_m);
@@ -862,7 +858,7 @@ int kmip_bio_create_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     }
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
-    result = resp_item.result_status;
+    enum result_status result = resp_item.result_status;
 
     if(result != KMIP_STATUS_SUCCESS)
     {
@@ -1077,8 +1073,7 @@ int kmip_bio_get_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     
     kmip_free_buffer(ctx, encoding, buffer_total_size);
     encoding = NULL;
-    
-    enum result_status result = KMIP_STATUS_OPERATION_FAILED;
+
     if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
     {
         kmip_free_response_message(ctx, &resp_m);
@@ -1087,7 +1082,7 @@ int kmip_bio_get_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     }
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
-    result = resp_item.result_status;
+    enum result_status result = resp_item.result_status;
     
     if(result != KMIP_STATUS_SUCCESS)
     {
@@ -1319,8 +1314,7 @@ int kmip_bio_destroy_symmetric_key_with_context(KMIP *ctx, BIO *bio,
         encoding = NULL;
         return(decode_result);
     }
-    
-    enum result_status result = KMIP_STATUS_OPERATION_FAILED;
+
     if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
     {
         kmip_free_response_message(ctx, &resp_m);
@@ -1330,7 +1324,7 @@ int kmip_bio_destroy_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     }
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
-    result = resp_item.result_status;
+    enum result_status result = resp_item.result_status;
     
     /* Clean up the response message and the encoding buffer. */
     kmip_free_response_message(ctx, &resp_m);


### PR DESCRIPTION
This change fixes several cases of ValueAssignedNeverRead, ensuring variables are either unmodified or set to reasonable defaults in their current scope.