### PR TITLE
Update kmip_get_num_items_next to use size_t

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -1450,7 +1450,7 @@ kmip_is_tag_type_next(const KMIP *ctx, enum tag t, enum type s)
     return(KMIP_TRUE);
 }
 
-int
+size_t
 kmip_get_num_items_next(KMIP *ctx, enum tag t)
 {
     if(ctx == NULL)
@@ -1458,7 +1458,7 @@ kmip_get_num_items_next(KMIP *ctx, enum tag t)
         return(0);
     }
     
-    int count = 0;
+    size_t count = 0;
     
     uint8 *index = ctx->index;
     uint32 length = 0;

--- a/kmip.h
+++ b/kmip.h
@@ -1278,7 +1278,7 @@ void kmip_set_alloc_error_message(KMIP *, size_t, const char *);
 void kmip_set_error_message(KMIP *, const char *);
 int kmip_is_tag_next(const KMIP *, enum tag);
 int kmip_is_tag_type_next(const KMIP *, enum tag, enum type);
-int kmip_get_num_items_next(KMIP *, enum tag);
+size_t kmip_get_num_items_next(KMIP *, enum tag);
 uint32 kmip_peek_tag(KMIP *);
 int kmip_is_attribute_tag(uint32);
 


### PR DESCRIPTION
This update changes the kmip_get_num_items_next utility function to use size_t for its counter, resolving a series of warnings for DangerousConversions.