### PR TITLE
Add safety checks when encoding length values

### DIFF
--- a/kmip.c
+++ b/kmip.c
@@ -6,6 +6,7 @@
  * repository for more information.
  */
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -8546,6 +8547,28 @@ kmip_encode_interval(KMIP *ctx, enum tag t, uint32 value)
 }
 
 int
+kmip_encode_length(KMIP *ctx, intptr length)
+{
+    // NOTE: Length is encoded as a signed 32-bit integer but the usage of this
+    // function uses the difference between two buffer pointers to determine
+    // the length in bytes that should be encoded. See the intptr typedef in
+    // the header for type details.
+    int result = 0;
+
+    if((length > INT_MAX) || (length < 0))
+    {
+        HANDLE_FAILURE(ctx, KMIP_INVALID_LENGTH);
+    }
+    else
+    {
+        result = kmip_encode_int32_be(ctx, (int32)length);
+        CHECK_RESULT(ctx, result);
+    }
+
+    return(KMIP_OK);
+}
+
+int
 kmip_encode_name(KMIP *ctx, const Name *value)
 {
     /* TODO (ph) Check for value == NULL? */
@@ -8566,8 +8589,8 @@ kmip_encode_name(KMIP *ctx, const Name *value)
     
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
-    
-    result = kmip_encode_int32_be(ctx, curr_index - value_index);
+
+    result = kmip_encode_length(ctx, curr_index - value_index);
     CHECK_RESULT(ctx, result);
     
     ctx->index = curr_index;
@@ -8607,7 +8630,7 @@ kmip_encode_protection_storage_masks(KMIP *ctx, const ProtectionStorageMasks *va
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
 
-    result = kmip_encode_int32_be(ctx, curr_index - value_index);
+    result = kmip_encode_length(ctx, curr_index - value_index);
     CHECK_RESULT(ctx, result);
 
     ctx->index = curr_index;
@@ -8841,7 +8864,7 @@ kmip_encode_attribute_v1(KMIP *ctx, const Attribute *value)
     curr_index = ctx->index;
     ctx->index = length_index;
     
-    result = kmip_encode_int32_be(ctx, curr_index - value_index);
+    result = kmip_encode_length(ctx, curr_index - value_index);
     CHECK_RESULT(ctx, result);
     
     ctx->index = curr_index;
@@ -9057,7 +9080,7 @@ kmip_encode_attributes(KMIP *ctx, const Attributes *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
 
-    result = kmip_encode_int32_be(ctx, curr_index - value_index);
+    result = kmip_encode_length(ctx, curr_index - value_index);
     CHECK_RESULT(ctx, result);
 
     ctx->index = curr_index;
@@ -9091,7 +9114,7 @@ kmip_encode_template_attribute(KMIP *ctx, const TemplateAttribute *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    result = kmip_encode_int32_be(ctx, curr_index - value_index);
+    result = kmip_encode_length(ctx, curr_index - value_index);
     CHECK_RESULT(ctx, result);
     
     ctx->index = curr_index;
@@ -9115,8 +9138,8 @@ kmip_encode_protocol_version(KMIP *ctx, const ProtocolVersion *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    kmip_encode_length(ctx, curr_index - value_index);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9161,7 +9184,10 @@ kmip_encode_application_specific_information(KMIP *ctx, const ApplicationSpecifi
 
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
-    kmip_encode_int32_be(ctx, curr_index - value_index);
+
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
 
     return(KMIP_OK);
@@ -9294,8 +9320,9 @@ kmip_encode_cryptographic_parameters(KMIP *ctx, const CryptographicParameters *v
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9323,8 +9350,9 @@ kmip_encode_encryption_key_information(KMIP *ctx, const EncryptionKeyInformation
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9352,8 +9380,9 @@ kmip_encode_mac_signature_key_information(KMIP *ctx, const MACSignatureKeyInform
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9405,8 +9434,9 @@ kmip_encode_key_wrapping_data(KMIP *ctx, const KeyWrappingData *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9429,8 +9459,9 @@ kmip_encode_transparent_symmetric_key(KMIP *ctx, const TransparentSymmetricKey *
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9558,8 +9589,9 @@ kmip_encode_key_value(KMIP *ctx, enum key_format_type format, const KeyValue *va
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9615,8 +9647,9 @@ kmip_encode_key_block(KMIP *ctx, const KeyBlock *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9638,8 +9671,9 @@ kmip_encode_symmetric_key(KMIP *ctx, const SymmetricKey *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9661,8 +9695,9 @@ kmip_encode_public_key(KMIP *ctx, const PublicKey *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9684,8 +9719,9 @@ kmip_encode_private_key(KMIP *ctx, const PrivateKey *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9731,8 +9767,9 @@ kmip_encode_key_wrapping_specification(KMIP *ctx, const KeyWrappingSpecification
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9795,8 +9832,9 @@ kmip_encode_create_request_payload(KMIP *ctx, const CreateRequestPayload *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9832,8 +9870,9 @@ kmip_encode_create_response_payload(KMIP *ctx, const CreateResponsePayload *valu
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9885,8 +9924,9 @@ kmip_encode_get_request_payload(KMIP *ctx, const GetRequestPayload *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9934,8 +9974,9 @@ kmip_encode_get_response_payload(KMIP *ctx, const GetResponsePayload *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9960,8 +10001,9 @@ kmip_encode_destroy_request_payload(KMIP *ctx, const DestroyRequestPayload *valu
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -9983,8 +10025,9 @@ kmip_encode_destroy_response_payload(KMIP *ctx, const DestroyResponsePayload *va
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10009,8 +10052,9 @@ kmip_encode_nonce(KMIP *ctx, const Nonce *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10038,8 +10082,9 @@ kmip_encode_username_password_credential(KMIP *ctx, const UsernamePasswordCreden
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10094,8 +10139,9 @@ kmip_encode_device_credential(KMIP *ctx, const DeviceCredential *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10132,8 +10178,9 @@ kmip_encode_attestation_credential(KMIP *ctx, const AttestationCredential *value
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10187,8 +10234,9 @@ kmip_encode_credential(KMIP *ctx, const Credential *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10210,8 +10258,9 @@ kmip_encode_authentication(KMIP *ctx, const Authentication *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10302,9 +10351,10 @@ kmip_encode_request_header(KMIP *ctx, const RequestHeader *value)
     
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
-    
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10371,8 +10421,9 @@ kmip_encode_response_header(KMIP *ctx, const ResponseHeader *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10432,8 +10483,9 @@ kmip_encode_request_batch_item(KMIP *ctx, const RequestBatchItem *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10503,8 +10555,9 @@ kmip_encode_response_batch_item(KMIP *ctx, const ResponseBatchItem *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10532,8 +10585,9 @@ kmip_encode_request_message(KMIP *ctx, const RequestMessage *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);
@@ -10561,8 +10615,9 @@ kmip_encode_response_message(KMIP *ctx, const ResponseMessage *value)
     uint8 *curr_index = ctx->index;
     ctx->index = length_index;
     
-    kmip_encode_int32_be(ctx, curr_index - value_index);
-    
+    result = kmip_encode_length(ctx, curr_index - value_index);
+    CHECK_RESULT(ctx, result);
+
     ctx->index = curr_index;
     
     return(KMIP_OK);

--- a/kmip.h
+++ b/kmip.h
@@ -29,6 +29,12 @@ typedef uint64_t uint64;
 
 typedef size_t memory_index;
 
+#ifdef intptr_t
+typedef intptr_t intptr;
+#else
+typedef int64 intptr;
+#endif
+
 typedef float real32;
 typedef double real64;
 
@@ -58,6 +64,7 @@ typedef double real64;
 #define KMIP_ERROR_BUFFER_UNDERFULL  (-18)
 #define KMIP_INVALID_ENCODING        (-19)
 #define KMIP_INVALID_FIELD           (-20)
+#define KMIP_INVALID_LENGTH          (-21)
 
 /*
 Enumerations
@@ -1488,6 +1495,7 @@ int kmip_encode_text_string(KMIP *, enum tag, const TextString *);
 int kmip_encode_byte_string(KMIP *, enum tag, const ByteString *);
 int kmip_encode_date_time(KMIP *, enum tag, int64);
 int kmip_encode_interval(KMIP *, enum tag, uint32);
+int kmip_encode_length(KMIP *, intptr);
 int kmip_encode_name(KMIP *, const Name *);
 int kmip_encode_attribute_name(KMIP *, enum attribute_type);
 int kmip_encode_attribute_v1(KMIP *, const Attribute *);


### PR DESCRIPTION
This change adds a new kmip_encode_length function that conducts a safe type conversion from the 64-bit buffer pointer delta to the signed 32-bit int that ultimately gets encoded. All encoding functions have been updated to use this new utility function.