### PR TITLE
Rj query locate master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ demo_create
 demo_get
 demo_destroy
 tests
+demo_query
+demo_locate

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ DESTDIR =
 PREFIX  = /usr/local
 KMIP    = kmip
 
-OFILES  = kmip.o kmip_memset.o kmip_bio.o
-LOFILES = kmip.lo kmip_memset.lo kmip_bio.lo
+OFILES  = kmip.o kmip_memset.o kmip_bio.o kmip_query.o kmip_locate.o ssl_connect.o
+LOFILES = kmip.lo kmip_memset.lo kmip_bio.lo kmip_query.lo kmip_locate.lo ssl_connect.lo
 
 all: demos tests $(LIBS)
 
@@ -72,15 +72,19 @@ uninstall_html_docs:
 docs: html_docs
 html_docs:
 	cd $(SRCDIR)/docs && make html && cd -
-demos: demo_create demo_get demo_destroy
+demos: demo_create demo_get demo_destroy demo_query demo_locate
 demo_get: demo_get.o $(OFILES)
-	$(CC) $(LDFLAGS) -o demo_get $? $(LDLIBS)
+	$(CC) $(LDFLAGS) -o demo_get $^ $(LDLIBS)
 demo_create: demo_create.o $(OFILES)
-	$(CC) $(LDFLAGS) -o demo_create $? $(LDLIBS)
+	$(CC) $(LDFLAGS) -o demo_create $^ $(LDLIBS)
 demo_destroy: demo_destroy.o $(OFILES)
-	$(CC) $(LDFLAGS) -o demo_destroy $? $(LDLIBS)
-tests: tests.o kmip.o kmip_memset.o
-	$(CC) $(LDFLAGS) -o tests tests.o kmip.o kmip_memset.o
+	$(CC) $(LDFLAGS) -o demo_destroy $^ $(LDLIBS)
+demo_query: demo_query.o $(OFILES)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+demo_locate: demo_locate.o $(OFILES)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+tests: tests.o kmip.o kmip_memset.o kmip_locate.o kmip_query.o
+	$(CC) $(LDFLAGS) -o tests $^
 
 demo_get.o: demo_get.c kmip_memset.h kmip.h
 demo_create.o: demo_create.c kmip_memset.h kmip.h
@@ -100,12 +104,21 @@ kmip_memset.lo: kmip_memset.c kmip_memset.h
 kmip_bio.o: kmip_bio.c kmip_bio.h
 kmip_bio.lo: kmip_bio.c kmip_bio.h
 
+ssl_connect.o: ssl_connect.c ssl_connect.h
+ssl_connect.lo: ssl_connect.c ssl_connect.h
+
+kmip_query.o: kmip_query.c kmip_query.h kmip.h kmip_memset.h  kmip_bio.h
+kmip_query.lo: kmip_query.c kmip_query.h kmip.h kmip_memset.h  kmip_bio.h
+
+kmip_locate.o: kmip_locate.c kmip_locate.h kmip_query.h kmip.h kmip_memset.h  kmip_bio.h
+kmip_locate.lo: kmip_locate.c kmip_locate.h kmip_query.h kmip.h kmip_memset.h  kmip_bio.h
+
 clean:
 	rm -f *.o *.lo
 clean_html_docs:
 	cd docs && make clean && cd ..
 cleanest:
-	rm -f demo_create demo_get demo_destroy tests *.o $(LOFILES) $(LIBS)
+	rm -f demo_create demo_get demo_destroy demo_locate demo_query tests *.o $(LOFILES) $(LIBS)
 	cd docs && make clean && cd ..
 
 .SUFFIXES: .c .o .lo .so

--- a/demo_create.c
+++ b/demo_create.c
@@ -292,16 +292,16 @@ use_low_level_api(BIO* bio,
     
     printf("The KMIP operation was executed with no errors.\n");
     printf("Result: ");
-    kmip_print_result_status_enum(result_status);
+    kmip_print_result_status_enum(stdout, result_status);
     printf(" (%d)\n\n", result_status);
 
     if (result_status != KMIP_STATUS_SUCCESS)
     {
         printf("Result Reason: ");
-        kmip_print_result_reason_enum(req.result_reason);
+        kmip_print_result_reason_enum(stdout, req.result_reason);
         printf("\n");
 
-        kmip_print_text_string(0, "Result Message", req.result_message);
+        kmip_print_text_string(stdout, 0, "Result Message", req.result_message);
     }
 
     if(result == KMIP_STATUS_SUCCESS)

--- a/demo_create.c
+++ b/demo_create.c
@@ -15,6 +15,7 @@
 #include "kmip.h"
 #include "kmip_bio.h"
 #include "kmip_memset.h"
+#include "ssl_connect.h"
 
 void
 print_help(const char *app)
@@ -27,12 +28,16 @@ print_help(const char *app)
     printf("-k path : path to client key file\n");
     printf("-p port : the port number of the KMIP server\n");
     printf("-r path : path to CA certificate file\n");
+    printf("-n name : name of new key\n");
+    printf("-g group : name of object group\n");
 }
 
 int
 parse_arguments(int argc, char **argv,
                 char **server_address, char **server_port,
                 char **client_certificate, char **client_key, char **ca_certificate,
+                char** key_name,
+                char **group,
                 int *print_usage)
 {
     if(argc <= 1)
@@ -55,6 +60,10 @@ parse_arguments(int argc, char **argv,
             *server_port = argv[++i];
         else if(strncmp(argv[i], "-r", 2) == 0)
             *ca_certificate = argv[++i];
+        else if(strncmp(argv[i], "-n", 2) == 0)
+            *key_name = argv[++i];
+        else if(strncmp(argv[i], "-g", 2) == 0)
+            *group = argv[++i];
         else
         {
             printf("Invalid option: '%s'\n", argv[i]);
@@ -67,71 +76,10 @@ parse_arguments(int argc, char **argv,
 }
 
 int
-use_low_level_api(const char *server_address,
-                  const char *server_port,
-                  const char *client_certificate,
-                  const char *client_key,
-                  const char *ca_certificate)
+use_low_level_api(BIO* bio,
+                  const char *key_name,
+                  const char *group)
 {
-    /* Set up the TLS connection to the KMIP server. */
-    SSL_CTX *ctx = NULL;
-    SSL *ssl = NULL;
-    OPENSSL_init_ssl(0, NULL);
-    ctx = SSL_CTX_new(TLS_client_method());
-    
-    printf("\n");
-    printf("Loading the client certificate: %s\n", client_certificate);
-    if(SSL_CTX_use_certificate_file(ctx, client_certificate, SSL_FILETYPE_PEM) != 1)
-    {
-        fprintf(stderr, "Loading the client certificate failed\n");
-        ERR_print_errors_fp(stderr);
-        SSL_CTX_free(ctx);
-        return(-1);
-    }
-    
-    printf("Loading the client key: %s\n", client_key);
-    if(SSL_CTX_use_PrivateKey_file(ctx, client_key, SSL_FILETYPE_PEM) != 1)
-    {
-        fprintf(stderr, "Loading the client key failed\n");
-        ERR_print_errors_fp(stderr);
-        SSL_CTX_free(ctx);
-        return(-1);
-    }
-    
-    printf("Loading the CA certificate: %s\n", ca_certificate);
-    if(SSL_CTX_load_verify_locations(ctx, ca_certificate, NULL) != 1)
-    {
-        fprintf(stderr, "Loading the CA certificate failed\n");
-        ERR_print_errors_fp(stderr);
-        SSL_CTX_free(ctx);
-        return(-1);
-    }
-    
-    BIO *bio = NULL;
-    bio = BIO_new_ssl_connect(ctx);
-    if(bio == NULL)
-    {
-        fprintf(stderr, "BIO_new_ssl_connect failed\n");
-        ERR_print_errors_fp(stderr);
-        SSL_CTX_free(ctx);
-        return(-1);
-    }
-    
-    BIO_get_ssl(bio, &ssl);
-    SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
-    BIO_set_conn_hostname(bio, server_address);
-    BIO_set_conn_port(bio, server_port);
-    if(BIO_do_connect(bio) != 1)
-    {
-        fprintf(stderr, "BIO_do_connect failed\n");
-        ERR_print_errors_fp(stderr);
-        BIO_free_all(bio);
-        SSL_CTX_free(ctx);
-        return(-1);
-    }
-    
-    printf("\n");
-    
     /* Set up the KMIP context and the initial encoding buffer. */
     KMIP kmip_context = {0};
     kmip_init(&kmip_context, NULL, 0, KMIP_1_0);
@@ -144,15 +92,13 @@ use_low_level_api(const char *server_address,
     if(encoding == NULL)
     {
         kmip_destroy(&kmip_context);
-        BIO_free_all(bio);
-        SSL_CTX_free(ctx);
         return(KMIP_MEMORY_ALLOC_FAILED);
     }
     kmip_set_buffer(&kmip_context, encoding, buffer_total_size);
     
     /* Build the request message. */
-    Attribute a[3] = {0};
-    for(int i = 0; i < 3; i++)
+    Attribute a[6] = {{0}};
+    for(int i = 0; i < 6; i++)
         kmip_init_attribute(&a[i]);
     
     enum cryptographic_algorithm algorithm = KMIP_CRYPTOALG_AES;
@@ -166,10 +112,42 @@ use_low_level_api(const char *server_address,
     int32 mask = KMIP_CRYPTOMASK_ENCRYPT | KMIP_CRYPTOMASK_DECRYPT;
     a[2].type = KMIP_ATTR_CRYPTOGRAPHIC_USAGE_MASK;
     a[2].value = &mask;
+
+    int idx = 3;
+
+    TextString g = { 0 };
+    if (group)
+    {
+        g.value = (char*) group;
+        g.size = kmip_strnlen_s(group, 50);
+
+        a[idx].type = KMIP_ATTR_OBJECT_GROUP;
+        a[idx].value = &g;
+
+        idx++;
+    }
+
+    TextString s = { 0 };
+    Name n = { 0 };
+    if (key_name)
+    {
+        s.value = (char*) key_name;
+        s.size = kmip_strnlen_s(key_name, 50);
+
+        n.value = &s;
+        n.type = KMIP_NAME_UNINTERPRETED_TEXT_STRING;
+
+        a[idx].type = KMIP_ATTR_NAME;
+        a[idx].value = &n;
+
+        idx++;
+    }
+
+    int attrib_count = idx;
     
     TemplateAttribute ta = {0};
     ta.attributes = a;
-    ta.attribute_count = ARRAY_LENGTH(a);
+    ta.attribute_count = attrib_count;
     
     ProtocolVersion pv = {0};
     kmip_init_protocol_version(&pv, kmip_context.version);
@@ -215,8 +193,6 @@ use_low_level_api(const char *server_address,
             printf("buffer for the Create request.\n");
 
             kmip_destroy(&kmip_context);
-            BIO_free_all(bio);
-            SSL_CTX_free(ctx);
             return(KMIP_MEMORY_ALLOC_FAILED);
         }
         
@@ -239,8 +215,6 @@ use_low_level_api(const char *server_address,
         encoding = NULL;
         kmip_set_buffer(&kmip_context, NULL, 0);
         kmip_destroy(&kmip_context);
-        BIO_free_all(bio);
-        SSL_CTX_free(ctx);
         return(encode_result);
     }
     
@@ -251,9 +225,6 @@ use_low_level_api(const char *server_address,
     int response_size = 0;
     
     int result = kmip_bio_send_request_encoding(&kmip_context, bio, (char *)encoding, kmip_context.index - kmip_context.buffer, &response, &response_size);
-    
-    BIO_free_all(bio);
-    SSL_CTX_free(ctx);
     
     printf("\n");
     if(result < 0)
@@ -321,9 +292,18 @@ use_low_level_api(const char *server_address,
     
     printf("The KMIP operation was executed with no errors.\n");
     printf("Result: ");
-    kmip_print_result_status_enum(stdout, result);
-    printf(" (%d)\n\n", result);
-    
+    kmip_print_result_status_enum(result_status);
+    printf(" (%d)\n\n", result_status);
+
+    if (result_status != KMIP_STATUS_SUCCESS)
+    {
+        printf("Result Reason: ");
+        kmip_print_result_reason_enum(req.result_reason);
+        printf("\n");
+
+        kmip_print_text_string(0, "Result Message", req.result_message);
+    }
+
     if(result == KMIP_STATUS_SUCCESS)
     {
         CreateResponsePayload *pld = (CreateResponsePayload *)req.response_payload;
@@ -347,6 +327,88 @@ use_low_level_api(const char *server_address,
     return(result_status);
 }
 
+
+int
+use_mid_level_api(BIO* bio,
+                  const char *key_name,
+                  const char *group,
+                  char* id,
+                  int*  idlen
+                  )
+{
+    /* Set up the KMIP context and the initial encoding buffer. */
+    KMIP kmip_context = {0};
+    kmip_init(&kmip_context, NULL, 0, KMIP_1_0);
+
+    /* Build the request message. */
+    Attribute a[6] = {{0}};
+    for(int i = 0; i < 6; i++)
+        kmip_init_attribute(&a[i]);
+
+    enum cryptographic_algorithm algorithm = KMIP_CRYPTOALG_AES;
+    a[0].type = KMIP_ATTR_CRYPTOGRAPHIC_ALGORITHM;
+    a[0].value = &algorithm;
+
+    int32 length = 256;
+    a[1].type = KMIP_ATTR_CRYPTOGRAPHIC_LENGTH;
+    a[1].value = &length;
+
+    int32 mask = KMIP_CRYPTOMASK_ENCRYPT | KMIP_CRYPTOMASK_DECRYPT;
+    a[2].type = KMIP_ATTR_CRYPTOGRAPHIC_USAGE_MASK;
+    a[2].value = &mask;
+
+    int idx = 3;
+
+    TextString g = { 0 };
+    if (group)
+    {
+        g.value = (char*) group;
+        g.size = kmip_strnlen_s(group, 50);
+
+        a[idx].type = KMIP_ATTR_OBJECT_GROUP;
+        a[idx].value = &g;
+
+        idx++;
+    }
+
+    TextString s = { 0 };
+    Name n = { 0 };
+    if (key_name)
+    {
+        s.value = (char*) key_name;
+        s.size = kmip_strnlen_s(key_name, 50);
+
+        n.value = &s;
+        n.type = KMIP_NAME_UNINTERPRETED_TEXT_STRING;
+
+        a[idx].type = KMIP_ATTR_NAME;
+        a[idx].value = &n;
+
+        idx++;
+    }
+
+    int attrib_count = idx;
+
+    TemplateAttribute ta = {0};
+    ta.attributes = a;
+    ta.attribute_count = attrib_count;
+
+    char* uuid = NULL;
+    int uuid_size = 0;
+    int result = kmip_bio_create_symmetric_key_with_context(&kmip_context, bio, &ta, &uuid, &uuid_size);
+
+    if (uuid)
+    {
+        strncpy(id, uuid, uuid_size);
+        id[uuid_size] = 0;
+        *idlen = uuid_size;
+        kmip_context.free_func(kmip_context.state, uuid);
+    }
+    kmip_destroy(&kmip_context);
+
+    return(result);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -355,9 +417,11 @@ main(int argc, char **argv)
     char *client_certificate = NULL;
     char *client_key = NULL;
     char *ca_certificate = NULL;
+    char *key_name = NULL;
+    char *group = NULL;
     int help = 0;
     
-    int error = parse_arguments(argc, argv, &server_address, &server_port, &client_certificate, &client_key, &ca_certificate, &help);
+    int error = parse_arguments(argc, argv, &server_address, &server_port, &client_certificate, &client_key, &ca_certificate, &key_name, &group, &help);
     if(error)
         return(error);
     if(help)
@@ -365,7 +429,31 @@ main(int argc, char **argv)
         print_help(argv[0]);
         return(0);
     }
+
+    ssl_initialize();
+    SSL_CTX* ctx = ssl_create_context(client_certificate, client_key, ca_certificate);
+    if (!ctx)
+        return 1;
+
+    SSL_SESSION* session = NULL;
     
-    use_low_level_api(server_address, server_port, client_certificate, client_key, ca_certificate);
+    BIO* bio = ssl_connect(ctx, server_address, server_port, &session);
+    if (!bio)
+        return 1;
+
+    //int rc = use_low_level_api(bio, key_name, group);
+    char id[128] = {0};
+    int id_len = 0;
+    int rc = use_mid_level_api(bio, key_name, group, id, &id_len);
+
+    printf("create rc=%d, id=%s\n", rc, id);
+
+    ssl_disconnect(bio);
+
+    if (session)
+        SSL_SESSION_free(session);
+
+    SSL_CTX_free(ctx);
+
     return(0);
 }

--- a/demo_locate.c
+++ b/demo_locate.c
@@ -1,0 +1,572 @@
+/* Copyright (c) 2018 The Johns Hopkins University/Applied Physics Labora`tory
+ * All Rights Reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "kmip.h"
+#include "kmip_bio.h"
+#include "kmip_memset.h"
+#include "kmip_query.h"
+#include "kmip_locate.h"
+#include "ssl_connect.h"
+
+
+void
+print_help(const char *app)
+{
+    printf("Usage: %s [flag value | flag] ...\n\n", app);
+    printf("Flags:\n");
+    printf("-a addr : the IP address of the KMIP server\n");
+    printf("-c path : path to client certificate file\n");
+    printf("-h      : print this help info\n");
+    printf("-k path : path to client key file\n");
+    printf("-p port : the port number of the KMIP server\n");
+    printf("-r path : path to CA certificate file\n");
+    printf("-n name : name of new key\n");
+    printf("-g group : name of object group\n");
+}
+
+int
+parse_arguments(int argc, char **argv,
+                char **server_address, char **server_port,
+                char **client_certificate, char **client_key, char **ca_certificate,
+                char **key_name,
+                char **group,
+                int *print_usage)
+{
+    if(argc <= 1)
+    {
+        print_help(argv[0]);
+        return(-1);
+    }
+    
+    for(int i = 1; i < argc; i++)
+    {
+        if(strncmp(argv[i], "-a", 2) == 0)
+        {
+            *server_address = argv[++i];
+        }
+        else if(strncmp(argv[i], "-c", 2) == 0)
+        {
+            *client_certificate = argv[++i];
+        }
+        else if(strncmp(argv[i], "-h", 2) == 0)
+        {
+            *print_usage = 1;
+        }
+        else if(strncmp(argv[i], "-k", 2) == 0)
+        {
+            *client_key = argv[++i];
+        }
+        else if(strncmp(argv[i], "-p", 2) == 0)
+        {
+            *server_port = argv[++i];
+        }
+        else if(strncmp(argv[i], "-r", 2) == 0)
+        {
+            *ca_certificate = argv[++i];
+        }
+        else if(strncmp(argv[i], "-n", 2) == 0)
+            *key_name = argv[++i];
+        else if(strncmp(argv[i], "-g", 2) == 0)
+            *group = argv[++i];
+        else
+        {
+            printf("Invalid option: '%s'\n", argv[i]);
+            print_help(argv[0]);
+            return(-1);
+        }
+    }
+    
+    return(0);
+}
+
+
+void *
+demo_calloc(void *state, size_t num, size_t size)
+{
+    void* ptr = calloc(num, size);
+    printf("demo_calloc called: state = %p, num = %zu, size = %zu, ptr = %p\n", state, num, size, ptr);
+    return(ptr);
+}
+
+void *
+demo_realloc(void *state, void *ptr, size_t size)
+{
+    void* reptr = realloc(ptr, size);
+    printf("demo_realloc called: state = %p, ptr = %p, size = %zu, reptr = %p\n", state, ptr, size, reptr);
+    return(realloc(reptr, size));
+}
+
+void
+demo_free(void *state, void *ptr)
+{
+    printf("demo_free called: state = %p, ptr = %p\n", state, ptr);
+    free(ptr);
+    return;
+}
+
+
+int use_low_level_api(KMIP *ctx, BIO *bio, Attribute* attribs, size_t attrib_count, LocateResponse* locate_result)
+{
+    if (ctx == NULL || bio == NULL || attribs == NULL || attrib_count == 0 || locate_result == NULL)
+    {
+        return(KMIP_ARG_INVALID);
+    }
+
+    printf("bio locate start \n");
+
+    size_t buffer_blocks = 1;
+    size_t buffer_block_size = 1024;
+    size_t buffer_total_size = buffer_blocks * buffer_block_size;
+
+    uint8 *encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+    if(encoding == NULL)
+    {
+        kmip_destroy(ctx);
+        return(KMIP_MEMORY_ALLOC_FAILED);
+    }
+    printf("encoding = %p\n", encoding);
+    kmip_set_buffer(ctx, encoding, buffer_total_size);
+
+    /* Build the request message. */
+
+
+    ProtocolVersion pv = {0};
+    kmip_init_protocol_version(&pv, ctx->version);
+
+    RequestHeader rh = {0};
+    kmip_init_request_header(&rh);
+
+    rh.protocol_version = &pv;
+    rh.maximum_response_size = ctx->max_message_size;
+    rh.time_stamp = time(NULL);
+    rh.batch_count = 1;
+
+
+    // copy input array to list
+    LinkedList *attribute_list = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    for(size_t i = 0; i < attrib_count; i++)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        item->data = kmip_deep_copy_attribute(ctx, &attribs[i]);
+        kmip_linked_list_enqueue(attribute_list, item);
+    }
+
+    LocateRequestPayload lrp = {0};
+    lrp.maximum_items = 12;
+    lrp.offset_items = 0;
+    lrp.storage_status_mask = 0;
+    lrp.group_member_option = 0;
+    lrp.attribute_list = attribute_list;
+
+    RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
+    rbi.operation = KMIP_OP_LOCATE;
+    rbi.request_payload = &lrp;
+
+    RequestMessage rm = {0};
+    rm.request_header = &rh;
+    rm.batch_items = &rbi;
+    rm.batch_count = 1;
+
+    /* Encode the request message. Dynamically resize the encoding buffer */
+    /* if it's not big enough. Once encoding succeeds, send the request   */
+    /* message.                                                           */
+    int encode_result = kmip_encode_request_message(ctx, &rm);
+    while(encode_result == KMIP_ERROR_BUFFER_FULL)
+    {
+        kmip_reset(ctx);
+        ctx->free_func(ctx->state, encoding);
+
+        buffer_blocks += 1;
+        buffer_total_size = buffer_blocks * buffer_block_size;
+
+        encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+        if(encoding == NULL)
+        {
+            printf("Failure: Could not automatically enlarge the encoding ");
+            printf("buffer for the Locate request.\n");
+
+            kmip_destroy(ctx);
+            return(KMIP_MEMORY_ALLOC_FAILED);
+        }
+        printf("encoding = %p\n", encoding);
+
+        kmip_set_buffer(ctx, encoding, buffer_total_size);
+        encode_result = kmip_encode_request_message(ctx, &rm);
+    }
+
+    if(encode_result != KMIP_OK)
+    {
+        printf("An error occurred while encoding the Locate request.\n");
+        printf("Error Code: %d\n", encode_result);
+        printf("Error Name: ");
+        kmip_print_error_string(encode_result);
+        printf("\n");
+        printf("Context Error: %s\n", ctx->error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(ctx);
+
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        encoding = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(encode_result);
+    }
+
+    kmip_print_request_message(&rm);
+    printf("\n");
+
+    char *response = NULL;
+    int response_size = 0;
+
+    printf("bio locate send request\n");
+
+    int result = kmip_bio_send_request_encoding(ctx, bio, (char *)encoding, ctx->index - ctx->buffer, &response, &response_size);
+
+    printf("bio locate response = %p\n", response);
+
+
+    printf("\n");
+    if(result < 0)
+    {
+        printf("An error occurred in locate request.\n");
+        printf("Error Code: %d\n", result);
+        printf("Error Name: ");
+        kmip_print_error_string(result);
+        printf("\n");
+        printf("Context Error: %s\n", ctx->error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(ctx);
+
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        kmip_free_buffer(ctx, response, response_size);
+        encoding = NULL;
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(result);
+    }
+
+    kmip_free_locate_request_payload(ctx, &lrp);
+
+
+    if (response)
+    {
+        FILE* out = fopen( "/tmp/kmip_locate.dat", "w" );
+        if (out)
+        {
+            int len = fwrite( response, response_size, 1, out );
+            fclose(out);
+        }
+        kmip_print_buffer(response, response_size);
+    }
+
+    printf("bio locate free encoding =  %p\n", encoding);
+    kmip_free_buffer(ctx, encoding, buffer_total_size);
+    encoding = NULL;
+    kmip_set_buffer(ctx, response, response_size);
+
+    /* Decode the response message and retrieve the operation results. */
+    ResponseMessage resp_m = {0};
+    int decode_result = kmip_decode_response_message(ctx, &resp_m);
+    if(decode_result != KMIP_OK)
+    {
+        printf("An error occurred while decoding the Locate response.\n");
+        printf("Error Code: %d\n", decode_result);
+        printf("Error Name: ");
+        kmip_print_error_string(decode_result);
+        printf("\n");
+        printf("Context Error: %s\n", ctx->error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(ctx);
+
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(decode_result);
+    }
+
+    kmip_print_response_message(&resp_m);
+    printf("\n");
+
+    if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
+    {
+        printf("Expected to find one batch item in the Locate response.\n");
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(KMIP_MALFORMED_RESPONSE);
+    }
+
+    ResponseBatchItem req = resp_m.batch_items[0];
+    enum result_status result_status = req.result_status;
+
+    printf("The KMIP operation was executed with no errors.\n");
+    printf("Result: ");
+    kmip_print_result_status_enum(result);
+    printf(" (%d)\n\n", result);
+
+    if(result == KMIP_STATUS_SUCCESS)
+    {
+        kmip_copy_locate_result(locate_result, (LocateResponsePayload*) req.response_payload);
+    }
+
+    printf("bio locate free response resp_m =  %p, response = %p\n", &resp_m, response);
+    if (locate_result->ids_size)
+    {
+        printf("id[0] = %s\n", locate_result->ids[0]);
+    }
+
+    /* Clean up the response message, the response buffer, and the KMIP */
+    /* context.                                                         */
+    kmip_free_response_message(ctx, &resp_m);
+    kmip_free_buffer(ctx, response, response_size);
+    response = NULL;
+
+    //kmip_set_buffer(ctx, NULL, 0);
+   // kmip_destroy(ctx);
+
+    printf("bio locate done \n");
+
+    return(result_status);
+}
+
+
+Credential* get_credential(char* device_serial_number,char* device_identifier, char* machine_identifier )
+{
+    static Credential credential = {0};
+    static DeviceCredential devc = {0};
+    static TextString sn = {0};
+    static TextString did = {0};
+    static TextString mid = {0};
+
+    memset(&devc,0, sizeof(devc) );
+    if (device_serial_number)
+    {
+        sn.value = device_serial_number;
+        sn.size = kmip_strnlen_s(device_serial_number, 50);
+        devc.device_serial_number = &sn;
+    }
+    if (device_identifier)
+    {
+        did.value = device_identifier;
+        did.size = kmip_strnlen_s(device_identifier, 50);
+        devc.device_identifier = &did;
+    }
+    if (machine_identifier)
+    {
+        mid.value = machine_identifier;
+        mid.size = kmip_strnlen_s(machine_identifier, 50);
+        devc.machine_identifier = &mid;
+    }
+
+    credential.credential_type = KMIP_CRED_DEVICE;
+    credential.credential_value = &devc;
+
+    return &credential;
+}
+
+int
+use_mid_level_api(BIO* bio,
+                  char *key_name,
+                  char *group,
+                  LocateResponse* locate_result)
+{
+    int result;
+
+    /* Set up the KMIP context and send the request message. */
+    KMIP kmip_context = {0};
+
+    //kmip_context.calloc_func = &demo_calloc;
+    //kmip_context.realloc_func = &demo_realloc;
+    //kmip_context.free_func = &demo_free;
+
+    kmip_init(&kmip_context, NULL, 0, KMIP_1_0);
+    
+
+#define USE_DEVICE_CREDENTIALS
+#ifdef USE_DEVICE_CREDENTIALS
+
+    char device_serial_number[] = "J3003MFY";
+    char device_identifier[] = "7X06";
+    char machine_identifier[] = "ED98BF5CE30E11E7BA717ED30AE6BACF";
+
+    Credential* cred = get_credential(device_serial_number,device_identifier, machine_identifier );
+    result = kmip_add_credential(&kmip_context, cred);
+    if(result != KMIP_OK)
+    {
+        printf("Failed to add credential to the KMIP context.\n");
+    }
+#endif // USE_DEVICE_CREDENTIALS
+
+    /* Build the request message. */
+    Attribute a[6] = {0};
+    for(int i = 0; i < 6; i++)
+        kmip_init_attribute(&a[i]);
+
+
+    int idx = 0;
+
+    // look for symmetric key
+    enum object_type loctype = KMIP_OBJTYPE_SYMMETRIC_KEY;
+    a[idx].type = KMIP_ATTR_OBJECT_TYPE;
+    a[idx].value = &loctype;
+    idx++;
+
+    if (0)
+    {
+        enum cryptographic_algorithm algorithm = KMIP_CRYPTOALG_AES;
+        a[idx].type = KMIP_ATTR_CRYPTOGRAPHIC_ALGORITHM;
+        a[idx].value = &algorithm;
+        idx++;
+
+        int32 length = 256;
+        a[idx].type = KMIP_ATTR_CRYPTOGRAPHIC_LENGTH;
+        a[idx].value = &length;
+        idx++;
+
+        int32 mask = KMIP_CRYPTOMASK_ENCRYPT | KMIP_CRYPTOMASK_DECRYPT;
+        a[idx].type = KMIP_ATTR_CRYPTOGRAPHIC_USAGE_MASK;
+        a[idx].value = &mask;
+        idx++;
+    }
+
+    TextString s = { 0 };
+    Name n = { 0 };
+    if (key_name)
+    {
+        s.value = (char*) key_name;
+        s.size = kmip_strnlen_s(key_name, 50);
+
+        n.value = &s;
+        n.type = KMIP_NAME_UNINTERPRETED_TEXT_STRING;
+
+        a[idx].type = KMIP_ATTR_NAME;
+        a[idx].value = &n;
+
+        idx++;
+    }
+
+    TextString g = { 0 };
+    if (group)
+    {
+        g.value = (char*) group;
+        g.size = kmip_strnlen_s(group, 50);
+
+        a[idx].type = KMIP_ATTR_OBJECT_GROUP;
+        a[idx].value = &g;
+
+        idx++;
+    }
+
+    int attrib_count = idx;
+
+    result = kmip_bio_locate_with_context(&kmip_context, bio, a, attrib_count, locate_result);
+    //result = use_low_level_api(&kmip_context, bio, a, attrib_count, locate_result);
+    
+    /* Handle the response results. */
+    printf("\n");
+    if(result < 0)
+    {
+        printf("An error occurred while running the locate.");
+        printf("Error Code: %d\n", result);
+        printf("Error Name: ");
+        kmip_print_error_string(result);
+        printf("\n");
+        printf("Context Error: %s\n", kmip_context.error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(&kmip_context);
+    }
+    else if(result >= 0)
+    {
+        printf("The KMIP operation was executed with no errors.\n");
+        printf("Result: ");
+        kmip_print_result_status_enum(result);
+        printf(" (%d)\n", result);
+        
+        if(result == KMIP_STATUS_SUCCESS)
+        {
+            printf("Locate results: ");
+            printf("located: %d\n", locate_result->located_items);
+            printf("\n");
+        }
+    }
+    
+    printf("\n");
+    
+    /* Clean up the KMIP context and return the results. */
+    kmip_set_buffer(&kmip_context, NULL, 0);
+    kmip_destroy(&kmip_context);
+    return(result);
+}
+
+int
+main(int argc, char **argv)
+{
+    char *server_address = NULL;
+    char *server_port = NULL;
+    char *client_certificate = NULL;
+    char *client_key = NULL;
+    char *ca_certificate = NULL;
+    char *key_name = NULL;
+    char *group = NULL;
+    int help = 0;
+    
+    int error = parse_arguments(argc, argv, &server_address, &server_port, &client_certificate, &client_key, &ca_certificate, &key_name, &group, &help);
+    if(error)
+    {
+        return(error);
+    }
+    if(help)
+    {
+        print_help(argv[0]);
+        return(0);
+    }
+
+    ssl_initialize();
+    SSL_CTX* ctx = ssl_create_context(client_certificate, client_key, ca_certificate);
+    if (!ctx)
+        return 1;
+
+    SSL_SESSION* session = NULL;
+
+    BIO* bio = ssl_connect(ctx, server_address, server_port, &session);
+    if (!bio)
+        return 1;
+
+    LocateResponse locate_result = {0};
+    int result = use_mid_level_api(bio, key_name, group, &locate_result);
+
+    if(result == KMIP_STATUS_SUCCESS)
+    {
+        printf("Locate results: ");
+        printf("located items: %d\n", locate_result.located_items);
+        printf("returned items: %d\n", locate_result.ids_size);
+        printf("id[0]=  %s\n", locate_result.ids[0]);
+        printf("\n");
+    }
+
+    ssl_disconnect(bio);
+
+    if (session)
+        SSL_SESSION_free(session);
+
+    SSL_CTX_free(ctx);
+
+    return(result);
+}

--- a/demo_query.c
+++ b/demo_query.c
@@ -1,0 +1,473 @@
+/* Copyright (c) 2018 The Johns Hopkins University/Applied Physics Labora`tory
+ * All Rights Reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "kmip.h"
+#include "kmip_bio.h"
+#include "kmip_memset.h"
+#include "kmip_query.h"
+#include "ssl_connect.h"
+
+
+void
+print_help(const char *app)
+{
+    printf("Usage: %s [flag value | flag] ...\n\n", app);
+    printf("Flags:\n");
+    printf("-a addr : the IP address of the KMIP server\n");
+    printf("-c path : path to client certificate file\n");
+    printf("-h      : print this help info\n");
+    printf("-k path : path to client key file\n");
+    printf("-p port : the port number of the KMIP server\n");
+    printf("-r path : path to CA certificate file\n");
+}
+
+int
+parse_arguments(int argc, char **argv,
+                char **server_address, char **server_port,
+                char **client_certificate, char **client_key, char **ca_certificate,
+                int *print_usage)
+{
+    if(argc <= 1)
+    {
+        print_help(argv[0]);
+        return(-1);
+    }
+    
+    for(int i = 1; i < argc; i++)
+    {
+        if(strncmp(argv[i], "-a", 2) == 0)
+        {
+            *server_address = argv[++i];
+        }
+        else if(strncmp(argv[i], "-c", 2) == 0)
+        {
+            *client_certificate = argv[++i];
+        }
+        else if(strncmp(argv[i], "-h", 2) == 0)
+        {
+            *print_usage = 1;
+        }
+        else if(strncmp(argv[i], "-k", 2) == 0)
+        {
+            *client_key = argv[++i];
+        }
+        else if(strncmp(argv[i], "-p", 2) == 0)
+        {
+            *server_port = argv[++i];
+        }
+        else if(strncmp(argv[i], "-r", 2) == 0)
+        {
+            *ca_certificate = argv[++i];
+        }
+        else
+        {
+            printf("Invalid option: '%s'\n", argv[i]);
+            print_help(argv[0]);
+            return(-1);
+        }
+    }
+    
+    return(0);
+}
+
+
+void *
+demo_calloc(void *state, size_t num, size_t size)
+{
+    void* ptr = calloc(num, size);
+    printf("demo_calloc called: state = %p, num = %zu, size = %zu, ptr = %p\n", state, num, size, ptr);
+    return(ptr);
+}
+
+void *
+demo_realloc(void *state, void *ptr, size_t size)
+{
+    void* reptr = realloc(ptr, size);
+    printf("demo_realloc called: state = %p, ptr = %p, size = %zu, reptr = %p\n", state, ptr, size, reptr);
+    return(realloc(reptr, size));
+}
+
+void
+demo_free(void *state, void *ptr)
+{
+    printf("demo_free called: state = %p, ptr = %p\n", state, ptr);
+    free(ptr);
+    return;
+}
+
+
+int use_low_level_api(KMIP *ctx, BIO *bio, enum query_function queries[], size_t query_count, QueryResponse* query_result)
+{
+    if (ctx == NULL || bio == NULL || queries == NULL || query_count == 0 || query_result == NULL)
+    {
+        return(KMIP_ARG_INVALID);
+    }
+
+    printf("bio query start \n");
+
+    size_t buffer_blocks = 1;
+    size_t buffer_block_size = 1024;
+    size_t buffer_total_size = buffer_blocks * buffer_block_size;
+
+    uint8 *encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+    if(encoding == NULL)
+    {
+        kmip_destroy(ctx);
+        return(KMIP_MEMORY_ALLOC_FAILED);
+    }
+    printf("encoding = %p\n", encoding);
+    kmip_set_buffer(ctx, encoding, buffer_total_size);
+
+    /* Build the request message. */
+
+
+    ProtocolVersion pv = {0};
+    kmip_init_protocol_version(&pv, ctx->version);
+
+    RequestHeader rh = {0};
+    kmip_init_request_header(&rh);
+
+    rh.protocol_version = &pv;
+    rh.maximum_response_size = ctx->max_message_size;
+    rh.time_stamp = time(NULL);
+    rh.batch_count = 1;
+
+    LinkedList *functions = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    for(size_t i = 0; i < query_count; i++)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        item->data = &queries[i];
+        kmip_linked_list_enqueue(functions, item);
+    }
+
+    printf("functions = %p\n", functions);
+
+    QueryRequestPayload qrp = {0};
+    qrp.functions = functions;
+
+    RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
+    rbi.operation = KMIP_OP_QUERY;
+    rbi.request_payload = &qrp;
+
+    RequestMessage rm = {0};
+    rm.request_header = &rh;
+    rm.batch_items = &rbi;
+    rm.batch_count = 1;
+
+    /* Encode the request message. Dynamically resize the encoding buffer */
+    /* if it's not big enough. Once encoding succeeds, send the request   */
+    /* message.                                                           */
+    int encode_result = kmip_encode_request_message(ctx, &rm);
+    while(encode_result == KMIP_ERROR_BUFFER_FULL)
+    {
+        kmip_reset(ctx);
+        ctx->free_func(ctx->state, encoding);
+
+        buffer_blocks += 1;
+        buffer_total_size = buffer_blocks * buffer_block_size;
+
+        encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+        if(encoding == NULL)
+        {
+            printf("Failure: Could not automatically enlarge the encoding ");
+            printf("buffer for the Query request.\n");
+
+            kmip_destroy(ctx);
+            return(KMIP_MEMORY_ALLOC_FAILED);
+        }
+        printf("encoding = %p\n", encoding);
+
+        kmip_set_buffer(ctx, encoding, buffer_total_size);
+        encode_result = kmip_encode_request_message(ctx, &rm);
+    }
+
+    if(encode_result != KMIP_OK)
+    {
+        printf("An error occurred while encoding the Query request.\n");
+        printf("Error Code: %d\n", encode_result);
+        printf("Error Name: ");
+        kmip_print_error_string(encode_result);
+        printf("\n");
+        printf("Context Error: %s\n", ctx->error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(ctx);
+
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        encoding = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(encode_result);
+    }
+
+    kmip_print_request_message(&rm);
+    printf("\n");
+
+    char *response = NULL;
+    int response_size = 0;
+
+    printf("bio query send request\n");
+
+    int result = kmip_bio_send_request_encoding(ctx, bio, (char *)encoding, ctx->index - ctx->buffer, &response, &response_size);
+
+    printf("bio query response = %p\n", response);
+
+
+    printf("\n");
+    if(result < 0)
+    {
+        printf("An error occurred in query request.\n");
+        printf("Error Code: %d\n", result);
+        printf("Error Name: ");
+        kmip_print_error_string(result);
+        printf("\n");
+        printf("Context Error: %s\n", ctx->error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(ctx);
+
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        kmip_free_buffer(ctx, response, response_size);
+        encoding = NULL;
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(result);
+    }
+
+    kmip_free_query_request_payload(ctx, &qrp);
+
+    if (response)
+    {
+        FILE* out = fopen( "/tmp/kmip_query.dat", "w" );
+        if (out)
+        {
+            int len = fwrite( response, response_size, 1, out );
+            fclose(out);
+        }
+        kmip_print_buffer(response, response_size);
+    }
+
+    printf("bio query free encoding =  %p\n", encoding);
+    kmip_free_buffer(ctx, encoding, buffer_total_size);
+    encoding = NULL;
+    kmip_set_buffer(ctx, response, response_size);
+
+    /* Decode the response message and retrieve the operation results. */
+    ResponseMessage resp_m = {0};
+    int decode_result = kmip_decode_response_message(ctx, &resp_m);
+    if(decode_result != KMIP_OK)
+    {
+        printf("An error occurred while decoding the Query response.\n");
+        printf("Error Code: %d\n", decode_result);
+        printf("Error Name: ");
+        kmip_print_error_string(decode_result);
+        printf("\n");
+        printf("Context Error: %s\n", ctx->error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(ctx);
+
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(decode_result);
+    }
+
+    kmip_print_response_message(&resp_m);
+    printf("\n");
+
+    if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
+    {
+        printf("Expected to find one batch item in the Query response.\n");
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(KMIP_MALFORMED_RESPONSE);
+    }
+
+    ResponseBatchItem req = resp_m.batch_items[0];
+    enum result_status result_status = req.result_status;
+
+    printf("The KMIP operation was executed with no errors.\n");
+    printf("Result: ");
+    kmip_print_result_status_enum(result);
+    printf(" (%d)\n\n", result);
+
+    if(result == KMIP_STATUS_SUCCESS)
+    {
+        kmip_copy_query_result(query_result, (QueryResponsePayload*) req.response_payload);
+    }
+
+    printf("bio query free response resp_m =  %p, response = %p\n", &resp_m, response);
+
+    /* Clean up the response message, the response buffer, and the KMIP */
+    /* context.                                                         */
+    kmip_free_response_message(ctx, &resp_m);
+    kmip_free_buffer(ctx, response, response_size);
+    response = NULL;
+
+    //kmip_set_buffer(ctx, NULL, 0);
+   // kmip_destroy(ctx);
+
+    printf("bio query done \n");
+
+    return(result_status);
+}
+
+
+int
+use_mid_level_api(BIO* bio,
+                  QueryResponse* query_result)
+{
+    /* Set up the KMIP context and send the request message. */
+    KMIP kmip_context = {0};
+
+    //kmip_context.calloc_func = &demo_calloc;
+    //kmip_context.realloc_func = &demo_realloc;
+    //kmip_context.free_func = &demo_free;
+
+    kmip_init(&kmip_context, NULL, 0, KMIP_1_0);
+    
+    enum query_function queries[] =
+    {
+        KMIP_QUERY_OPERATIONS,
+        KMIP_QUERY_OBJECTS,
+        KMIP_QUERY_SERVER_INFORMATION,
+        KMIP_QUERY_APPLICATION_NAMESPACES,
+    };
+
+    int result = kmip_bio_query_with_context(&kmip_context, bio, queries, ARRAY_LENGTH(queries), query_result);
+    //int result = use_low_level_api(&kmip_context, bio, queries, ARRAY_LENGTH(queries), query_result);
+    
+    /* Handle the response results. */
+    printf("\n");
+    if(result < 0)
+    {
+        printf("An error occurred while running the query.");
+        printf("Error Code: %d\n", result);
+        printf("Error Name: ");
+        kmip_print_error_string(result);
+        printf("\n");
+        printf("Context Error: %s\n", kmip_context.error_message);
+        printf("Stack trace:\n");
+        kmip_print_stack_trace(&kmip_context);
+    }
+    else if(result >= 0)
+    {
+        printf("The KMIP operation was executed with no errors.\n");
+        printf("Result: ");
+        kmip_print_result_status_enum(result);
+        printf(" (%d)\n", result);
+        
+        if(result == KMIP_STATUS_SUCCESS)
+        {
+            printf("Query results: ");
+            printf("vendor: %s\n", query_result->vendor_identification);
+            printf("\n");
+        }
+    }
+    
+    printf("\n");
+    
+    /* Clean up the KMIP context and return the results. */
+    kmip_set_buffer(&kmip_context, NULL, 0);
+    kmip_destroy(&kmip_context);
+    return(result);
+}
+
+int
+main(int argc, char **argv)
+{
+    char *server_address = NULL;
+    char *server_port = NULL;
+    char *client_certificate = NULL;
+    char *client_key = NULL;
+    char *ca_certificate = NULL;
+    int help = 0;
+    
+    int error = parse_arguments(argc, argv, &server_address, &server_port, &client_certificate, &client_key, &ca_certificate, &help);
+    if(error)
+    {
+        return(error);
+    }
+    if(help)
+    {
+        print_help(argv[0]);
+        return(0);
+    }
+
+    ssl_initialize();
+    SSL_CTX* ctx = ssl_create_context(client_certificate, client_key, ca_certificate);
+    if (!ctx)
+        return 1;
+
+    SSL_SESSION* session = NULL;
+
+    {
+        BIO* bio = ssl_connect(ctx, server_address, server_port, &session);
+        if (!bio)
+        {
+            printf("error: %x, %s", ssl_error, ssl_saved_error);
+            return 1;
+        }
+
+        QueryResponse query_result = {0};
+        int result = use_mid_level_api(bio, &query_result);
+        if(result == KMIP_STATUS_SUCCESS)
+        {
+            printf("Query results: ");
+            printf("vendor: %s\n", query_result.vendor_identification);
+            printf("num ops: %d\n", query_result.operations_size);
+            printf("num objs: %d\n", query_result.objects_size);
+            printf("server info: %d\n", query_result.server_information_valid );
+            printf("\n");
+        }
+
+        ssl_disconnect(bio);
+    }
+
+    // reuse session
+    {
+        BIO* bio = ssl_connect(ctx, server_address, server_port, &session);
+        if (!bio)
+        {
+            printf("error: %x, %s", ssl_error, ssl_saved_error);
+            return 1;
+        }
+
+        QueryResponse query_result = {0};
+        int result = use_mid_level_api(bio, &query_result);
+        if(result == KMIP_STATUS_SUCCESS)
+        {
+            printf("Query results: ");
+            printf("vendor: %s\n", query_result.vendor_identification);
+            printf("num ops: %d\n", query_result.operations_size);
+            printf("num objs: %d\n", query_result.objects_size);
+            printf("server info: %d\n", query_result.server_information_valid );
+            printf("\n");
+        }
+
+        ssl_disconnect(bio);
+    }
+
+    if (session)
+        SSL_SESSION_free(session);
+
+    SSL_CTX_free(ctx);
+
+    return(0);
+}

--- a/kmip.c
+++ b/kmip.c
@@ -1206,7 +1206,7 @@ kmip_clear_errors(KMIP *ctx)
     
     for(size_t i = 0; i < ARRAY_LENGTH(ctx->errors); i++)
     {
-        ctx->errors[i] = (ErrorFrame){0};
+        ctx->errors[i] = (ErrorFrame){{0},0};
     }
     ctx->frame_index = ctx->errors;
     
@@ -4414,11 +4414,11 @@ kmip_print_request_payload(FILE *f, int indent, enum operation type, void *value
         break;
         
         case KMIP_OP_QUERY:
-        kmip_print_query_request_payload(indent, value);
+        kmip_print_query_request_payload(f, indent, value);
         break;
 
         case KMIP_OP_LOCATE:
-        kmip_print_locate_request_payload(indent, value);
+        kmip_print_locate_request_payload(f, indent, value);
         break;
 
         default:
@@ -4445,11 +4445,11 @@ kmip_print_response_payload(FILE *f, int indent, enum operation type, void *valu
         break;
         
         case KMIP_OP_QUERY:
-        kmip_print_query_response_payload(indent, value);
+        kmip_print_query_response_payload(f, indent, value);
         break;
 
         case KMIP_OP_LOCATE:
-        kmip_print_locate_response_payload(indent, value);
+        kmip_print_locate_response_payload(f, indent, value);
         break;
 
         default:
@@ -6615,9 +6615,6 @@ kmip_compare_attributes(const Attributes *a, const Attributes *b)
             {
                 if(a_item != b_item)
                 {
-                    if(!a_item || !b_item)
-                        break;
-
                     Attribute *a_data = (Attribute *)a_item->data;
                     Attribute *b_data = (Attribute *)b_item->data;
                     if(kmip_compare_attribute(a_data, b_data) == KMIP_FALSE)
@@ -8973,11 +8970,6 @@ kmip_encode_attribute_v1(KMIP *ctx, const Attribute *value)
         result = kmip_encode_enum(ctx, t, *(int32 *)value->value);
         break;
 
-        case KMIP_ATTR_OBJECT_GROUP:
-        result = kmip_encode_text_string(ctx, t, (TextString*)value->value);
-        break;
-
-        
         case KMIP_ATTR_OBJECT_GROUP:
         {
             result = kmip_encode_text_string(ctx, t, (TextString*)value->value);

--- a/kmip.h
+++ b/kmip.h
@@ -416,8 +416,10 @@ enum operation
 {
     /* KMIP 1.0 */
     KMIP_OP_CREATE  = 0x01,
+    KMIP_OP_LOCATE  = 0x08,
     KMIP_OP_GET     = 0x0A,
-    KMIP_OP_DESTROY = 0x14
+    KMIP_OP_DESTROY = 0x14,
+    KMIP_OP_QUERY   = 0x18
 };
 
 enum padding_method
@@ -452,6 +454,29 @@ enum protection_storage_mask
     KMIP_PROTECT_OUTSOURCED        = 0x00000800,
     KMIP_PROTECT_VALIDATED         = 0x00001000,
     KMIP_PROTECT_SAME_JURISDICTION = 0x00002000
+};
+
+enum query_function
+{
+    /* KMIP 1.0 */
+    KMIP_QUERY_OPERATIONS                  = 0x0001,
+    KMIP_QUERY_OBJECTS                     = 0x0002,
+    KMIP_QUERY_SERVER_INFORMATION          = 0x0003,
+    KMIP_QUERY_APPLICATION_NAMESPACES      = 0x0004,
+    /* KMIP 1.1 */
+    KMIP_QUERY_EXTENSION_LIST              = 0x0005,
+    KMIP_QUERY_EXTENSION_MAP               = 0x0006,
+    /* KMIP 1.2 */
+    KMIP_QUERY_ATTESTATION_TYPES           = 0x0007,
+    /* KMIP 1.3 */
+    KMIP_QUERY_RNGS                        = 0x0008,
+    KMIP_QUERY_VALIDATIONS                 = 0x0009,
+    KMIP_QUERY_PROFILES                    = 0x000A,
+    KMIP_QUERY_CAPABILITIES                = 0x000B,
+    KMIP_QUERY_CLIENT_REGISTRATION_METHODS = 0x000C,
+    /* KMIP 2.0 */
+    KMIP_QUERY_DEFAULTS_INFORMATION        = 0x000D,
+    KMIP_QUERY_STORAGE_PROTECTION_MASKS    = 0x000E
 };
 
 enum result_reason
@@ -600,6 +625,7 @@ enum tag
     KMIP_TAG_KEY_WRAPPING_SPECIFICATION       = 0x420047,
     KMIP_TAG_MAC_SIGNATURE                    = 0x42004D,
     KMIP_TAG_MAC_SIGNATURE_KEY_INFORMATION    = 0x42004E,
+    KMIP_TAG_MAXIMUM_ITEMS                    = 0x42004F,
     KMIP_TAG_MAXIMUM_RESPONSE_SIZE            = 0x420050,
     KMIP_TAG_NAME                             = 0x420053,
     KMIP_TAG_NAME_TYPE                        = 0x420054,
@@ -616,6 +642,7 @@ enum tag
     KMIP_TAG_PROTOCOL_VERSION_MAJOR           = 0x42006A,
     KMIP_TAG_PROTOCOL_VERSION_MINOR           = 0x42006B,
     KMIP_TAG_PUBLIC_KEY                       = 0x42006D,
+    KMIP_TAG_QUERY_FUNCTION                   = 0x420074,
     KMIP_TAG_REQUEST_HEADER                   = 0x420077,
     KMIP_TAG_REQUEST_MESSAGE                  = 0x420078,
     KMIP_TAG_REQUEST_PAYLOAD                  = 0x420079,
@@ -626,13 +653,16 @@ enum tag
     KMIP_TAG_RESULT_REASON                    = 0x42007E,
     KMIP_TAG_RESULT_STATUS                    = 0x42007F,
     KMIP_TAG_KEY_ROLE_TYPE                    = 0x420083,
+    KMIP_TAG_SERVER_INFORMATION               = 0x420088,
     KMIP_TAG_STATE                            = 0x42008D,
+    KMIP_TAG_STORAGE_STATUS_MASK              = 0x42008E,
     KMIP_TAG_SYMMETRIC_KEY                    = 0x42008F,
     KMIP_TAG_TEMPLATE_ATTRIBUTE               = 0x420091,
     KMIP_TAG_TIME_STAMP                       = 0x420092,
     KMIP_TAG_UNIQUE_BATCH_ITEM_ID             = 0x420093,
     KMIP_TAG_UNIQUE_IDENTIFIER                = 0x420094,
     KMIP_TAG_USERNAME                         = 0x420099,
+    KMIP_TAG_VENDOR_IDENTIFICATION            = 0x42009D,
     KMIP_TAG_WRAPPING_METHOD                  = 0x42009E,
     KMIP_TAG_PASSWORD                         = 0x4200A1,
     /* KMIP 1.1 */
@@ -641,6 +671,7 @@ enum tag
     KMIP_TAG_MACHINE_IDENTIFIER               = 0x4200A9,
     KMIP_TAG_MEDIA_IDENTIFIER                 = 0x4200AA,
     KMIP_TAG_NETWORK_IDENTIFIER               = 0x4200AB,
+    KMIP_TAG_OBJECT_GROUP_MEMBER              = 0x4200AC,
     KMIP_TAG_DIGITAL_SIGNATURE_ALGORITHM      = 0x4200AE,
     KMIP_TAG_DEVICE_SERIAL_NUMBER             = 0x4200B0,
     /* KMIP 1.2 */
@@ -658,6 +689,8 @@ enum tag
     KMIP_TAG_INITIAL_COUNTER_VALUE            = 0x4200D1,
     KMIP_TAG_INVOCATION_FIELD_LENGTH          = 0x4200D2,
     KMIP_TAG_ATTESTATION_CAPABLE_INDICATOR    = 0x4200D3,
+    KMIP_TAG_OFFSET_ITEMS                     = 0x4200D4,
+    KMIP_TAG_LOCATED_ITEMS                    = 0x4200D5,
     /* KMIP 1.4 */
     KMIP_TAG_KEY_WRAP_TYPE                    = 0x4200F8,
     KMIP_TAG_SALT_LENGTH                      = 0x420100,
@@ -669,6 +702,15 @@ enum tag
     KMIP_TAG_SERVER_CORRELATION_VALUE         = 0x420106,
     /* KMIP 2.0 */
     KMIP_TAG_ATTRIBUTES                       = 0x420125,
+    KMIP_TAG_SERVER_NAME                      = 0x42012D,  /* KMIP 2.0 */
+    KMIP_TAG_SERVER_SERIAL_NUMBER             = 0x42012E,
+    KMIP_TAG_SERVER_VERSION                   = 0x42012F,
+    KMIP_TAG_SERVER_LOAD                      = 0x420130,
+    KMIP_TAG_PRODUCT_NAME                     = 0x420131,
+    KMIP_TAG_BUILD_LEVEL                      = 0x420132,
+    KMIP_TAG_BUILD_DATE                       = 0x420133,
+    KMIP_TAG_CLUSTER_INFO                     = 0x420134,
+    KMIP_TAG_ALTERNATE_FAILOVER_ENDPOINTS     = 0x420135,
     KMIP_TAG_EPHEMERAL                        = 0x420154,
     KMIP_TAG_SERVER_HASHED_PASSWORD           = 0x420155,
     KMIP_TAG_PROTECTION_STORAGE_MASK          = 0x42015E,
@@ -1306,6 +1348,7 @@ void kmip_init_request_batch_item(RequestBatchItem *);
 Printing Functions
 */
 
+<<<<<<< HEAD
 void kmip_print_buffer(FILE *, void *, int);
 void kmip_print_stack_trace(FILE *, KMIP *);
 void kmip_print_error_string(FILE *, int);
@@ -1434,6 +1477,7 @@ Name * kmip_deep_copy_name(KMIP *, const Name *);
 CryptographicParameters * kmip_deep_copy_cryptographic_parameters(KMIP *, const CryptographicParameters *);
 ApplicationSpecificInformation * kmip_deep_copy_application_specific_information(KMIP *, const ApplicationSpecificInformation *);
 Attribute * kmip_deep_copy_attribute(KMIP *, const Attribute *);
+char* kmip_copy_textstring(char* dest, TextString* src, size_t size);
 
 /*
 Comparison Functions

--- a/kmip.h
+++ b/kmip.h
@@ -1348,7 +1348,6 @@ void kmip_init_request_batch_item(RequestBatchItem *);
 Printing Functions
 */
 
-<<<<<<< HEAD
 void kmip_print_buffer(FILE *, void *, int);
 void kmip_print_stack_trace(FILE *, KMIP *);
 void kmip_print_error_string(FILE *, int);

--- a/kmip_bio.c
+++ b/kmip_bio.c
@@ -14,6 +14,9 @@
 
 #include "kmip.h"
 #include "kmip_memset.h"
+#include "kmip_bio.h"
+#include "kmip_query.h"
+#include "kmip_locate.h"
 
 /*
 OpenSSH BIO API
@@ -674,6 +677,46 @@ int kmip_bio_get_symmetric_key(BIO *bio,
     return(result);
 }
 
+LastResult last_result = {0};
+
+void kmip_clear_last_result(void)
+{
+    last_result.operation     = 0;
+    last_result.result_status = KMIP_STATUS_SUCCESS;
+    last_result.result_reason = 0;
+    last_result.result_message[0] = 0;
+}
+
+int kmip_set_last_result(ResponseBatchItem* value)
+{
+    if (value)
+    {
+        last_result.operation = value->operation;
+        last_result.result_status = value->result_status;
+        last_result.result_reason = value->result_reason;
+        if (value->result_message)
+            kmip_copy_textstring(last_result.result_message, value->result_message, sizeof(last_result.result_message));
+        else
+            last_result.result_message[0] = 0;
+    }
+    return 0;
+}
+
+const LastResult* kmip_get_last_result(void)
+{
+    return &last_result;
+}
+
+int kmip_last_reason(void)
+{
+    return last_result.result_reason;
+}
+
+const char* kmip_last_message(void)
+{
+    return last_result.result_message;
+}
+
 int kmip_bio_create_symmetric_key_with_context(KMIP *ctx, BIO *bio,
                                                TemplateAttribute *template_attribute,
                                                char **id, int *id_size)
@@ -860,6 +903,8 @@ int kmip_bio_create_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     ResponseBatchItem resp_item = resp_m.batch_items[0];
     enum result_status result = resp_item.result_status;
 
+    kmip_set_last_result(&resp_item);
+
     if(result != KMIP_STATUS_SUCCESS)
     {
         kmip_free_response_message(ctx, &resp_m);
@@ -870,16 +915,22 @@ int kmip_bio_create_symmetric_key_with_context(KMIP *ctx, BIO *bio,
         return(result);
     }
     
-    CreateResponsePayload *pld = (CreateResponsePayload *)resp_item.response_payload;
-    TextString *unique_identifier = pld->unique_identifier;
-    
-    char *result_id = ctx->calloc_func(ctx->state, 1, unique_identifier->size);
-    *id_size = unique_identifier->size;
-    for(int i = 0; i < *id_size; i++)
+    if (result == KMIP_STATUS_SUCCESS)
     {
-        result_id[i] = unique_identifier->value[i];
+        CreateResponsePayload *pld = (CreateResponsePayload *)resp_item.response_payload;
+        if (pld)
+        {
+            TextString *unique_identifier = pld->unique_identifier;
+
+            char *result_id = ctx->calloc_func(ctx->state, 1, unique_identifier->size);
+            *id_size = unique_identifier->size;
+            for(int i = 0; i < *id_size; i++)
+            {
+                result_id[i] = unique_identifier->value[i];
+            }
+            *id = result_id;
+        }
     }
-    *id = result_id;
     
     /* Clean up the response message and the encoding buffer. */
     kmip_free_response_message(ctx, &resp_m);
@@ -1083,6 +1134,8 @@ int kmip_bio_get_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     
     ResponseBatchItem resp_item = resp_m.batch_items[0];
     enum result_status result = resp_item.result_status;
+
+    kmip_set_last_result(&resp_item);
     
     if(result != KMIP_STATUS_SUCCESS)
     {
@@ -1333,6 +1386,332 @@ int kmip_bio_destroy_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     kmip_set_buffer(ctx, NULL, 0);
     
     return(result);
+}
+
+int kmip_bio_query_with_context(KMIP *ctx, BIO *bio, enum query_function queries[], size_t query_count, QueryResponse* query_result)
+{
+    if (ctx == NULL || bio == NULL || queries == NULL || query_count == 0 || query_result == NULL)
+    {
+        return(KMIP_ARG_INVALID);
+    }
+
+    size_t buffer_blocks = 1;
+    size_t buffer_block_size = 1024;
+    size_t buffer_total_size = buffer_blocks * buffer_block_size;
+
+    uint8 *encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+    if(encoding == NULL)
+    {
+        kmip_destroy(ctx);
+        return(KMIP_MEMORY_ALLOC_FAILED);
+    }
+    kmip_set_buffer(ctx, encoding, buffer_total_size);
+
+    /* Build the request message. */
+
+
+    ProtocolVersion pv = {0};
+    kmip_init_protocol_version(&pv, ctx->version);
+
+    RequestHeader rh = {0};
+    kmip_init_request_header(&rh);
+
+    rh.protocol_version = &pv;
+    rh.maximum_response_size = ctx->max_message_size;
+    rh.time_stamp = time(NULL);
+    rh.batch_count = 1;
+
+    LinkedList *functions = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    for(size_t i = 0; i < query_count; i++)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        item->data = &queries[i];
+        kmip_linked_list_enqueue(functions, item);
+    }
+
+    QueryRequestPayload qrp = {0};
+    qrp.functions = functions;
+
+    RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
+    rbi.operation = KMIP_OP_QUERY;
+    rbi.request_payload = &qrp;
+
+    RequestMessage rm = {0};
+    rm.request_header = &rh;
+    rm.batch_items = &rbi;
+    rm.batch_count = 1;
+
+    /* Encode the request message. Dynamically resize the encoding buffer */
+    /* if it's not big enough. Once encoding succeeds, send the request   */
+    /* message.                                                           */
+    int encode_result = kmip_encode_request_message(ctx, &rm);
+    while(encode_result == KMIP_ERROR_BUFFER_FULL)
+    {
+        kmip_reset(ctx);
+        ctx->free_func(ctx->state, encoding);
+
+        buffer_blocks += 1;
+        buffer_total_size = buffer_blocks * buffer_block_size;
+
+        encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+        if(encoding == NULL)
+        {
+            kmip_destroy(ctx);
+            return(KMIP_MEMORY_ALLOC_FAILED);
+        }
+        kmip_set_buffer(ctx, encoding, buffer_total_size);
+        encode_result = kmip_encode_request_message(ctx, &rm);
+    }
+
+    if(encode_result != KMIP_OK)
+    {
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        encoding = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(encode_result);
+    }
+
+    char *response = NULL;
+    int response_size = 0;
+
+    int result = kmip_bio_send_request_encoding(ctx, bio, (char *)encoding, ctx->index - ctx->buffer, &response, &response_size);
+    if(result < 0)
+    {
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        kmip_free_buffer(ctx, response, response_size);
+        encoding = NULL;
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(result);
+    }
+
+    kmip_free_query_request_payload(ctx, &qrp);
+
+    if (response)
+    {
+        FILE* out = fopen( "/tmp/kmip_query.dat", "w" );
+        if (out)
+        {
+            fwrite( response, response_size, 1, out );
+            fclose(out);
+        }
+        // kmip_print_buffer(response, response_size);
+    }
+
+    kmip_free_buffer(ctx, encoding, buffer_total_size);
+    encoding = NULL;
+    kmip_set_buffer(ctx, response, response_size);
+
+    /* Decode the response message and retrieve the operation results. */
+    ResponseMessage resp_m = {0};
+    int decode_result = kmip_decode_response_message(ctx, &resp_m);
+    if(decode_result != KMIP_OK)
+    {
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(decode_result);
+    }
+
+    if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
+    {
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(KMIP_MALFORMED_RESPONSE);
+    }
+
+    ResponseBatchItem resp_item = resp_m.batch_items[0];
+    enum result_status result_status = resp_item.result_status;
+
+    kmip_set_last_result(&resp_item);
+
+    if(result == KMIP_STATUS_SUCCESS)
+    {
+        kmip_copy_query_result(query_result, (QueryResponsePayload*) resp_item.response_payload);
+    }
+
+    /* Clean up the response message, the response buffer, and the KMIP */
+    /* context.                                                         */
+    kmip_free_response_message(ctx, &resp_m);
+    kmip_free_buffer(ctx, response, response_size);
+    response = NULL;
+
+    return(result_status);
+}
+
+
+int kmip_bio_locate_with_context(KMIP *ctx, BIO *bio, Attribute* attribs, size_t attrib_count, LocateResponse* locate_result)
+{
+    if (ctx == NULL || bio == NULL || attribs == NULL || attrib_count == 0 || locate_result == NULL)
+    {
+        return(KMIP_ARG_INVALID);
+    }
+
+    size_t buffer_blocks = 1;
+    size_t buffer_block_size = 1024;
+    size_t buffer_total_size = buffer_blocks * buffer_block_size;
+
+    uint8 *encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+    if(encoding == NULL)
+    {
+        kmip_destroy(ctx);
+        return(KMIP_MEMORY_ALLOC_FAILED);
+    }
+    kmip_set_buffer(ctx, encoding, buffer_total_size);
+
+    /* Build the request message. */
+
+
+    ProtocolVersion pv = {0};
+    kmip_init_protocol_version(&pv, ctx->version);
+
+    RequestHeader rh = {0};
+    kmip_init_request_header(&rh);
+
+    rh.protocol_version = &pv;
+    rh.maximum_response_size = ctx->max_message_size;
+    rh.time_stamp = time(NULL);
+    rh.batch_count = 1;
+
+
+    // copy input array to list
+    LinkedList *attribute_list = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    for(size_t i = 0; i < attrib_count; i++)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        item->data = kmip_deep_copy_attribute(ctx, &attribs[i]);
+        kmip_linked_list_enqueue(attribute_list, item);
+    }
+
+    LocateRequestPayload lrp = {0};
+    lrp.maximum_items = 12;
+    lrp.offset_items = 0;
+    lrp.storage_status_mask = 0;
+    lrp.group_member_option = 0;
+    lrp.attribute_list = attribute_list;
+
+    RequestBatchItem rbi = {0};
+    kmip_init_request_batch_item(&rbi);
+    rbi.operation = KMIP_OP_LOCATE;
+    rbi.request_payload = &lrp;
+
+    RequestMessage rm = {0};
+    rm.request_header = &rh;
+    rm.batch_items = &rbi;
+    rm.batch_count = 1;
+
+    /* Encode the request message. Dynamically resize the encoding buffer */
+    /* if it's not big enough. Once encoding succeeds, send the request   */
+    /* message.                                                           */
+    int encode_result = kmip_encode_request_message(ctx, &rm);
+    while(encode_result == KMIP_ERROR_BUFFER_FULL)
+    {
+        kmip_reset(ctx);
+        ctx->free_func(ctx->state, encoding);
+
+        buffer_blocks += 1;
+        buffer_total_size = buffer_blocks * buffer_block_size;
+
+        encoding = ctx->calloc_func(ctx->state, buffer_blocks, buffer_block_size);
+        if(encoding == NULL)
+        {
+            kmip_destroy(ctx);
+            return(KMIP_MEMORY_ALLOC_FAILED);
+        }
+
+        kmip_set_buffer(ctx, encoding, buffer_total_size);
+        encode_result = kmip_encode_request_message(ctx, &rm);
+    }
+
+    if(encode_result != KMIP_OK)
+    {
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        encoding = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(encode_result);
+    }
+
+    char *response = NULL;
+    int response_size = 0;
+
+    int result = kmip_bio_send_request_encoding(ctx, bio, (char *)encoding, ctx->index - ctx->buffer, &response, &response_size);
+    if(result < 0)
+    {
+        kmip_free_buffer(ctx, encoding, buffer_total_size);
+        kmip_free_buffer(ctx, response, response_size);
+        encoding = NULL;
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(result);
+    }
+
+    kmip_free_locate_request_payload(ctx, &lrp);
+
+
+    if (response)
+    {
+        FILE* out = fopen( "/tmp/kmip_locate.dat", "w" );
+        if (out)
+        {
+            fwrite( response, response_size, 1, out );
+            fclose(out);
+        }
+    }
+
+    kmip_free_buffer(ctx, encoding, buffer_total_size);
+    encoding = NULL;
+    kmip_set_buffer(ctx, response, response_size);
+
+    /* Decode the response message and retrieve the operation results. */
+    ResponseMessage resp_m = {0};
+    int decode_result = kmip_decode_response_message(ctx, &resp_m);
+    if(decode_result != KMIP_OK)
+    {
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(decode_result);
+    }
+
+    if(resp_m.batch_count != 1 || resp_m.batch_items == NULL)
+    {
+        kmip_free_response_message(ctx, &resp_m);
+        kmip_free_buffer(ctx, response, response_size);
+        response = NULL;
+        kmip_set_buffer(ctx, NULL, 0);
+        kmip_destroy(ctx);
+        return(KMIP_MALFORMED_RESPONSE);
+    }
+
+    ResponseBatchItem resp_item = resp_m.batch_items[0];
+    enum result_status result_status = resp_item.result_status;
+
+    kmip_set_last_result(&resp_item);
+
+    if(result == KMIP_STATUS_SUCCESS)
+    {
+        kmip_copy_locate_result(locate_result, (LocateResponsePayload*) resp_item.response_payload);
+    }
+
+    /* Clean up the response message, the response buffer, and the KMIP */
+    /* context.                                                         */
+    kmip_free_response_message(ctx, &resp_m);
+    kmip_free_buffer(ctx, response, response_size);
+    response = NULL;
+
+    return(result_status);
 }
 
 int kmip_bio_send_request_encoding(KMIP *ctx, BIO *bio,

--- a/kmip_bio.h
+++ b/kmip_bio.h
@@ -12,6 +12,24 @@
 #include <openssl/ssl.h>
 #include "kmip.h"
 
+typedef struct query_response QueryResponse;
+typedef struct locate_response LocateResponse;
+
+typedef struct last_result
+{
+    enum operation operation;
+    enum result_status result_status;
+    enum result_reason result_reason;
+    char result_message[128];
+} LastResult;
+
+int kmip_set_last_result(ResponseBatchItem*);
+const LastResult* kmip_get_last_result(void);
+int kmip_last_reason(void);
+const char* kmip_last_message(void);
+void kmip_clear_last_result(void);
+
+
 /*
 OpenSSH BIO API
 */
@@ -23,6 +41,9 @@ int kmip_bio_destroy_symmetric_key(BIO *, char *, int);
 int kmip_bio_create_symmetric_key_with_context(KMIP *, BIO *, TemplateAttribute *, char **, int *);
 int kmip_bio_get_symmetric_key_with_context(KMIP *, BIO *, char *, int, char **, int *);
 int kmip_bio_destroy_symmetric_key_with_context(KMIP *, BIO *, char *, int);
+
+int kmip_bio_query_with_context(KMIP *ctx, BIO *bio, enum query_function queries[], size_t query_count, QueryResponse* query_result);
+int kmip_bio_locate_with_context(KMIP *ctx, BIO *bio, Attribute* attribs, size_t attrib_count, LocateResponse* locate_result);
 
 int kmip_bio_send_request_encoding(KMIP *, BIO *, char *, int, char **, int *);
 

--- a/kmip_locate.c
+++ b/kmip_locate.c
@@ -1,0 +1,363 @@
+/* Copyright (c) 2018 The Johns Hopkins University/Applied Physics Laboratory
+ * All Rights Reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "kmip.h"
+#include "kmip_memset.h"
+#include "kmip_bio.h"
+#include "kmip_query.h"
+#include "kmip_locate.h"
+
+/*
+Locate Utilities
+*/
+
+
+
+
+void kmip_free_attribute_list(KMIP* ctx, LinkedList* value)
+{
+    if(value != NULL)
+    {
+        LinkedListItem *curr = kmip_linked_list_pop(value);
+        while(curr != NULL)
+        {
+            Attribute *attribute = (Attribute *)curr->data;
+            kmip_free_attribute(ctx, attribute);
+            ctx->free_func(ctx->state, attribute);
+            ctx->free_func(ctx->state, curr);
+            curr = kmip_linked_list_pop(value);
+        }
+    }
+}
+
+int kmip_encode_attribute_list(KMIP* ctx, LinkedList* value)
+{
+    CHECK_ENCODE_ARGS(ctx, value);
+
+    int result = 0;
+
+    if(value != NULL)
+    {
+        LinkedListItem *curr = value->head;
+        while(curr != NULL)
+        {
+            Attribute *attribute = (Attribute *)curr->data;
+            result = kmip_encode_attribute(ctx, attribute);
+            CHECK_RESULT(ctx, result);
+
+            curr = curr->next;
+        }
+    }
+
+    return(KMIP_OK);
+
+}
+
+void kmip_print_attribute_list(int indent, LinkedList* value)
+{
+    if(value != NULL)
+    {
+        LinkedListItem *curr = value->head;
+        while(curr != NULL)
+        {
+            Attribute *attribute = (Attribute *)curr->data;
+            kmip_print_attribute(indent + 2, attribute);
+
+            curr = curr->next;
+        }
+    }
+}
+
+void kmip_print_locate_request_payload(int indent, LocateRequestPayload * value)
+{
+    if (value)
+    {
+        printf("%*sMaximum items: ", indent + 2, "");
+        kmip_print_integer(value->maximum_items);
+        printf("\n");
+
+        printf("%*sOffset items: ", indent + 2, "");
+        kmip_print_integer(value->offset_items);
+        printf("\n");
+
+        printf("%*sStorage status: ", indent + 2, "");
+        kmip_print_integer(value->storage_status_mask);
+        printf("\n");
+
+        if(value->attribute_list)
+            kmip_print_attribute_list(indent + 2, value->attribute_list);
+    }
+}
+
+void kmip_free_locate_request_payload(KMIP* ctx, LocateRequestPayload *value)
+{
+    //printf("** free request payload\n");
+    if (value->attribute_list)
+    {
+        kmip_free_attribute_list(ctx, value->attribute_list);
+        ctx->free_func(ctx->state, value->attribute_list);
+        value->attribute_list = NULL;
+    }
+}
+
+int kmip_compare_locate_request_payload(const LocateRequestPayload *a, const LocateRequestPayload *b)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+
+int
+kmip_encode_locate_request_payload(KMIP* ctx, const LocateRequestPayload* value)
+{
+    int result = 0;
+    result = kmip_encode_int32_be(ctx, TAG_TYPE(KMIP_TAG_REQUEST_PAYLOAD, KMIP_TYPE_STRUCTURE));
+    CHECK_RESULT(ctx, result);
+
+    uint8 *length_index = ctx->index;
+    uint8 *value_index = ctx->index += 4;
+
+    if(value->maximum_items)
+    {
+        result = kmip_encode_integer(ctx, KMIP_TAG_MAXIMUM_ITEMS, value->maximum_items);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if (value->offset_items)
+    {
+        result = kmip_encode_integer(ctx, KMIP_TAG_OFFSET_ITEMS, value->offset_items);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if (value->storage_status_mask)
+    {
+        result = kmip_encode_integer(ctx, KMIP_TAG_STORAGE_STATUS_MASK, value->storage_status_mask);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if (value->group_member_option)
+    {
+        result = kmip_encode_enum(ctx, KMIP_TAG_OBJECT_GROUP_MEMBER, value->group_member_option);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(ctx->version < KMIP_2_0)
+    {
+        if (value->attribute_list)
+        {
+            // copy input list to allow freeing
+            LinkedList *list = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+            LinkedListItem *curr = value->attribute_list->head;
+            while(curr != NULL)
+            {
+                LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+                item->data = kmip_deep_copy_attribute(ctx, curr->data);
+                kmip_linked_list_enqueue(list, item);
+
+                curr = curr->next;
+            }
+
+            result = kmip_encode_attribute_list(ctx, list);
+
+            kmip_free_attribute_list(ctx, list);
+            ctx->free_func(ctx->state, list);
+
+            CHECK_RESULT(ctx, result);
+        }
+    }
+    else
+    {
+        // todo : copy attrib list into Attribute - see kmip.c
+
+
+    }
+
+    uint8 *curr_index = ctx->index;
+    ctx->index = length_index;
+
+    kmip_encode_int32_be(ctx, curr_index - value_index);
+
+    ctx->index = curr_index;
+
+    return(KMIP_OK);
+}
+
+int kmip_decode_locate_request_payload(KMIP* ctx, LocateRequestPayload *value)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+
+void kmip_print_locate_response_payload(int indent, LocateResponsePayload *value)
+{
+    printf("%*sLocated Items: ", indent + 2, "");
+    kmip_print_integer(value->located_items);
+    printf("\n");
+
+    kmip_print_unique_identifiers(indent, value->unique_ids);
+}
+void kmip_free_locate_response_payload(KMIP* ctx, LocateResponsePayload *value)
+{
+    //printf("** free response payload\n");
+    if (value->unique_ids)
+    {
+        kmip_free_unique_identifiers(ctx, value->unique_ids);
+        ctx->free_func(ctx->state, value->unique_ids);
+        value->unique_ids = NULL;
+    }
+}
+int kmip_compare_locate_response_payload(const LocateResponsePayload *a, const LocateResponsePayload *b)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+int kmip_encode_locate_response_payload(KMIP* ctx, const LocateResponsePayload *value)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+int kmip_decode_locate_response_payload(KMIP* ctx, LocateResponsePayload *value)
+{
+    CHECK_BUFFER_FULL(ctx, 8);
+
+    int result = 0;
+    int32 tag_type = 0;
+    uint32 length = 0;
+
+    kmip_decode_int32_be(ctx, &tag_type);
+    CHECK_TAG_TYPE(ctx, tag_type, KMIP_TAG_RESPONSE_PAYLOAD, KMIP_TYPE_STRUCTURE);
+
+    kmip_decode_int32_be(ctx, &length);
+    CHECK_BUFFER_FULL(ctx, length);
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_LOCATED_ITEMS))
+    {
+        result = kmip_decode_integer(ctx, KMIP_TAG_LOCATED_ITEMS, &value->located_items);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_UNIQUE_IDENTIFIER))
+    {
+        value->unique_ids = ctx->calloc_func(ctx->state, 1, sizeof(UniqueIdentifiers));
+        CHECK_NEW_MEMORY(ctx, value->unique_ids, sizeof(UniqueIdentifiers), "Unique_Identifiers");
+        result = kmip_decode_unique_identifiers(ctx, value->unique_ids);
+        CHECK_RESULT(ctx, result);
+    }
+
+    return(KMIP_OK);
+}
+
+
+void
+kmip_print_unique_identifiers(int indent, UniqueIdentifiers* value)
+{
+    printf("%*sUnique IDs @ %p\n", indent, "", (void *)value);
+
+    if(value != NULL)
+    {
+        printf("%*sUnique IDs: %zu\n", indent + 2, "", value->unique_identifier_list->size);
+        LinkedListItem *curr = value->unique_identifier_list->head;
+        size_t count = 1;
+        while(curr != NULL)
+        {
+            printf("%*sUnique ID: %zu: ", indent + 4, "", count);
+            kmip_print_text_string(indent + 2, "", curr->data);
+            printf("\n");
+
+            curr = curr->next;
+            count++;
+        }
+    }
+}
+
+void
+kmip_copy_unique_ids(char ids[][MAX_LOCATE_LEN], size_t* id_size, UniqueIdentifiers* value, int max_ids)
+{
+    size_t idx = 0;
+    if(value != NULL)
+    {
+        LinkedListItem *curr = value->unique_identifier_list->head;
+        while(curr != NULL && idx < max_ids)
+        {
+            kmip_copy_textstring(ids[idx], curr->data, MAX_LOCATE_LEN-1);
+            curr = curr->next;
+            idx++;
+        }
+    }
+    *id_size = idx;
+}
+
+
+void
+kmip_free_unique_identifiers(KMIP *ctx, UniqueIdentifiers* value)
+{
+    //printf("** free uniq ids \n");
+    if(value != NULL)
+    {
+        if(value->unique_identifier_list != NULL)
+        {
+            LinkedListItem *curr = kmip_linked_list_pop(value->unique_identifier_list);
+            while(curr != NULL)
+            {
+                kmip_free_text_string(ctx, curr->data);
+                ctx->free_func(ctx->state, curr->data);
+                curr->data = NULL;
+                ctx->free_func(ctx->state, curr);
+                curr = kmip_linked_list_pop(value->unique_identifier_list);
+            }
+            ctx->free_func(ctx->state, value->unique_identifier_list);
+            value->unique_identifier_list= NULL;
+        }
+    }
+
+    return;
+}
+
+
+int kmip_decode_unique_identifiers(KMIP* ctx, UniqueIdentifiers* value)
+{
+    int result = 0;
+
+    //printf("** decode uniq ids \n");
+
+    value->unique_identifier_list = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    CHECK_NEW_MEMORY(ctx, value->unique_identifier_list, sizeof(LinkedList), "LinkedList");
+
+    uint32 tag = kmip_peek_tag(ctx);
+    while(tag == KMIP_TAG_UNIQUE_IDENTIFIER)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        CHECK_NEW_MEMORY(ctx, item, sizeof(LinkedListItem), "LinkedListItem");
+        kmip_linked_list_enqueue(value->unique_identifier_list, item);
+
+        item->data = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, item->data, sizeof(TextString), "Unique ID text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_UNIQUE_IDENTIFIER, item->data);
+        CHECK_RESULT(ctx, result);
+
+        tag = kmip_peek_tag(ctx);
+    }
+
+    return(KMIP_OK);
+}
+
+
+void
+kmip_copy_locate_result(LocateResponse* locate_result, LocateResponsePayload *pld)
+{
+    if(pld != NULL)
+    {
+        locate_result->located_items = pld->located_items;
+
+        kmip_copy_unique_ids(locate_result->ids, &locate_result->ids_size, pld->unique_ids, MAX_LOCATE_IDS);
+    }
+}
+
+
+
+

--- a/kmip_locate.c
+++ b/kmip_locate.c
@@ -62,7 +62,7 @@ int kmip_encode_attribute_list(KMIP* ctx, LinkedList* value)
 
 }
 
-void kmip_print_attribute_list(int indent, LinkedList* value)
+void kmip_print_attribute_list(FILE* f, int indent, LinkedList* value)
 {
     if(value != NULL)
     {
@@ -70,31 +70,31 @@ void kmip_print_attribute_list(int indent, LinkedList* value)
         while(curr != NULL)
         {
             Attribute *attribute = (Attribute *)curr->data;
-            kmip_print_attribute(indent + 2, attribute);
+            kmip_print_attribute(f, indent + 2, attribute);
 
             curr = curr->next;
         }
     }
 }
 
-void kmip_print_locate_request_payload(int indent, LocateRequestPayload * value)
+void kmip_print_locate_request_payload(FILE* f, int indent, LocateRequestPayload * value)
 {
     if (value)
     {
-        printf("%*sMaximum items: ", indent + 2, "");
-        kmip_print_integer(value->maximum_items);
-        printf("\n");
+        fprintf(f, "%*sMaximum items: ", indent + 2, "");
+        kmip_print_integer(f, value->maximum_items);
+        fprintf(f, "\n");
 
-        printf("%*sOffset items: ", indent + 2, "");
-        kmip_print_integer(value->offset_items);
-        printf("\n");
+        fprintf(f, "%*sOffset items: ", indent + 2, "");
+        kmip_print_integer(f, value->offset_items);
+        fprintf(f, "\n");
 
-        printf("%*sStorage status: ", indent + 2, "");
-        kmip_print_integer(value->storage_status_mask);
-        printf("\n");
+        fprintf(f, "%*sStorage status: ", indent + 2, "");
+        kmip_print_integer(f, value->storage_status_mask);
+        fprintf(f, "\n");
 
         if(value->attribute_list)
-            kmip_print_attribute_list(indent + 2, value->attribute_list);
+            kmip_print_attribute_list(f, indent + 2, value->attribute_list);
     }
 }
 
@@ -111,6 +111,8 @@ void kmip_free_locate_request_payload(KMIP* ctx, LocateRequestPayload *value)
 
 int kmip_compare_locate_request_payload(const LocateRequestPayload *a, const LocateRequestPayload *b)
 {
+    (void) a;
+    (void) b;
     return(KMIP_NOT_IMPLEMENTED);
 }
 
@@ -191,16 +193,18 @@ kmip_encode_locate_request_payload(KMIP* ctx, const LocateRequestPayload* value)
 
 int kmip_decode_locate_request_payload(KMIP* ctx, LocateRequestPayload *value)
 {
+    (void) ctx;
+    (void) value;
     return(KMIP_NOT_IMPLEMENTED);
 }
 
-void kmip_print_locate_response_payload(int indent, LocateResponsePayload *value)
+void kmip_print_locate_response_payload(FILE* f, int indent, LocateResponsePayload *value)
 {
-    printf("%*sLocated Items: ", indent + 2, "");
-    kmip_print_integer(value->located_items);
-    printf("\n");
+    fprintf(f, "%*sLocated Items: ", indent + 2, "");
+    kmip_print_integer(f, value->located_items);
+    fprintf(f, "\n");
 
-    kmip_print_unique_identifiers(indent, value->unique_ids);
+    kmip_print_unique_identifiers(f, indent, value->unique_ids);
 }
 void kmip_free_locate_response_payload(KMIP* ctx, LocateResponsePayload *value)
 {
@@ -214,10 +218,14 @@ void kmip_free_locate_response_payload(KMIP* ctx, LocateResponsePayload *value)
 }
 int kmip_compare_locate_response_payload(const LocateResponsePayload *a, const LocateResponsePayload *b)
 {
+    (void) a;
+    (void) b;
     return(KMIP_NOT_IMPLEMENTED);
 }
 int kmip_encode_locate_response_payload(KMIP* ctx, const LocateResponsePayload *value)
 {
+    (void) ctx;
+    (void) value;
     return(KMIP_NOT_IMPLEMENTED);
 }
 int kmip_decode_locate_response_payload(KMIP* ctx, LocateResponsePayload *value)
@@ -253,20 +261,20 @@ int kmip_decode_locate_response_payload(KMIP* ctx, LocateResponsePayload *value)
 
 
 void
-kmip_print_unique_identifiers(int indent, UniqueIdentifiers* value)
+kmip_print_unique_identifiers(FILE* f, int indent, UniqueIdentifiers* value)
 {
-    printf("%*sUnique IDs @ %p\n", indent, "", (void *)value);
+    fprintf(f, "%*sUnique IDs @ %p\n", indent, "", (void *)value);
 
     if(value != NULL)
     {
-        printf("%*sUnique IDs: %zu\n", indent + 2, "", value->unique_identifier_list->size);
+        fprintf(f, "%*sUnique IDs: %zu\n", indent + 2, "", value->unique_identifier_list->size);
         LinkedListItem *curr = value->unique_identifier_list->head;
         size_t count = 1;
         while(curr != NULL)
         {
-            printf("%*sUnique ID: %zu: ", indent + 4, "", count);
-            kmip_print_text_string(indent + 2, "", curr->data);
-            printf("\n");
+            fprintf(f, "%*sUnique ID: %zu: ", indent + 4, "", count);
+            kmip_print_text_string(f, indent + 2, "", curr->data);
+            fprintf(f, "\n");
 
             curr = curr->next;
             count++;
@@ -275,7 +283,7 @@ kmip_print_unique_identifiers(int indent, UniqueIdentifiers* value)
 }
 
 void
-kmip_copy_unique_ids(char ids[][MAX_LOCATE_LEN], size_t* id_size, UniqueIdentifiers* value, int max_ids)
+kmip_copy_unique_ids(char ids[][MAX_LOCATE_LEN], size_t* id_size, UniqueIdentifiers* value, unsigned max_ids)
 {
     size_t idx = 0;
     if(value != NULL)

--- a/kmip_locate.h
+++ b/kmip_locate.h
@@ -83,13 +83,13 @@ typedef struct locate_response
     char             ids[MAX_LOCATE_IDS][MAX_LOCATE_LEN];
 } LocateResponse;
 
-void kmip_print_locate_request_payload(int, LocateRequestPayload *);
+void kmip_print_locate_request_payload(FILE*, int, LocateRequestPayload *);
 void kmip_free_locate_request_payload(KMIP *, LocateRequestPayload *);
 int kmip_compare_locate_request_payload(const LocateRequestPayload *, const LocateRequestPayload *);
 int kmip_encode_locate_request_payload(KMIP *, const LocateRequestPayload *);
 int kmip_decode_locate_request_payload(KMIP *, LocateRequestPayload *);
 
-void kmip_print_locate_response_payload(int, LocateResponsePayload *);
+void kmip_print_locate_response_payload(FILE*, int, LocateResponsePayload *);
 void kmip_free_locate_response_payload(KMIP *, LocateResponsePayload *);
 int kmip_compare_locate_response_payload(const LocateResponsePayload *, const LocateResponsePayload *);
 int kmip_encode_locate_response_payload(KMIP *, const LocateResponsePayload *);
@@ -97,7 +97,7 @@ int kmip_decode_locate_response_payload(KMIP *, LocateResponsePayload *);
 
 
 
-void kmip_print_unique_identifiers(int indent, UniqueIdentifiers* value);
+void kmip_print_unique_identifiers(FILE*, int indent, UniqueIdentifiers* value);
 void kmip_free_unique_identifiers(KMIP *ctx, UniqueIdentifiers* value);
 int kmip_decode_unique_identifiers(KMIP* ctx, UniqueIdentifiers* value);
 

--- a/kmip_locate.h
+++ b/kmip_locate.h
@@ -1,0 +1,106 @@
+
+
+
+// Object Group Member Option
+enum group_member_option
+{
+    group_member_fresh       =  0x00000001,
+    group_member_default     =  0x00000002
+};
+
+
+//Extensions                 0x8XXXXXXX
+
+/*
+
+4.35 Object Group
+
+A Managed Object MAY be part of a group of objects. An object MAY belong to more than one group of objects.
+To assign an object to a group of objects, the object group name SHOULD be set into this attribute.
+
+Item                   Encoding
+Object Group           Text String
+
+*/
+
+/*
+Request Payload
+
+Item                    REQUIRED    Description
+Maximum Items           No          An Integer object that indicates the maximum number of object identifiers the server MAY return.
+Offset Items            No          An Integer object that indicates the number of object identifiers to skip that satisfy the identification criteria specified in the request.
+Storage Status Mask     No          An Integer object (used as a bit mask) that indicates whether only on-line objects, only archived objects, destroyed objects or any combination of these, are to be searched. If omitted, then only on-line objects SHALL be returned.
+Object Group Member     No          An Enumeration object that indicates the object group member type.
+Attributes              Yes         Specifies an attribute and its value(s) that are REQUIRED to match those in a candidate object (according to the matching rules defined above).
+
+Note: the Attributes structure MAY be empty indicating all objects should match.
+
+*/
+
+
+/*
+
+When the Object Group attribute and the Object Group Member flag are specified in the request,
+and the value specified for Object Group Member is ‘Group Member Fresh’,
+matching candidate objects SHALL be fresh objects from the object group.
+
+If there are no more fresh objects in the group, the server MAY choose to generate a new object on-the-fly,
+based on server policy. If the value specified for Object Group Member is ‘Group Member Default’,
+the server locates the default object as defined by server policy.
+
+
+*/
+
+typedef struct locate_request_payload
+{
+    int32  maximum_items;      // An Integer object that indicates the maximum number of object identifiers the server MAY return.
+    int32  offset_items;       // An Integer object that indicates the number of object identifiers to skip that satisfy the identification criteria specified in the request.
+    int32  storage_status_mask; // An Integer object (used as a bit mask) that indicates whether only on-line objects, only archived objects, destroyed objects or any combination of these, are to be searched. If omitted, then only on-line objects SHALL be returned.
+    enum   group_member_option group_member_option; // An Enumeration object that indicates the object group member type.
+    LinkedList* attribute_list; // Specifies an attribute and its value(s) that are REQUIRED to match those in a candidate object (according to the matching rules defined above).
+} LocateRequestPayload;
+
+
+typedef struct unique_identifiers
+{
+    LinkedList *unique_identifier_list;
+} UniqueIdentifiers;
+
+typedef struct locate_response_payload
+{
+    int32 located_items;
+    UniqueIdentifiers* unique_ids;
+} LocateResponsePayload;
+
+
+#define MAX_LOCATE_IDS   32
+#define MAX_LOCATE_LEN   128
+
+typedef struct locate_response
+{
+    int              located_items;
+    size_t           ids_size;
+    char             ids[MAX_LOCATE_IDS][MAX_LOCATE_LEN];
+} LocateResponse;
+
+void kmip_print_locate_request_payload(int, LocateRequestPayload *);
+void kmip_free_locate_request_payload(KMIP *, LocateRequestPayload *);
+int kmip_compare_locate_request_payload(const LocateRequestPayload *, const LocateRequestPayload *);
+int kmip_encode_locate_request_payload(KMIP *, const LocateRequestPayload *);
+int kmip_decode_locate_request_payload(KMIP *, LocateRequestPayload *);
+
+void kmip_print_locate_response_payload(int, LocateResponsePayload *);
+void kmip_free_locate_response_payload(KMIP *, LocateResponsePayload *);
+int kmip_compare_locate_response_payload(const LocateResponsePayload *, const LocateResponsePayload *);
+int kmip_encode_locate_response_payload(KMIP *, const LocateResponsePayload *);
+int kmip_decode_locate_response_payload(KMIP *, LocateResponsePayload *);
+
+
+
+void kmip_print_unique_identifiers(int indent, UniqueIdentifiers* value);
+void kmip_free_unique_identifiers(KMIP *ctx, UniqueIdentifiers* value);
+int kmip_decode_unique_identifiers(KMIP* ctx, UniqueIdentifiers* value);
+
+
+void kmip_copy_locate_result(LocateResponse* locate_result, LocateResponsePayload *pld);
+

--- a/kmip_query.c
+++ b/kmip_query.c
@@ -1,0 +1,1042 @@
+/* Copyright (c) 2018 The Johns Hopkins University/Applied Physics Laboratory
+ * All Rights Reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "kmip.h"
+#include "kmip_memset.h"
+#include "kmip_bio.h"
+#include "kmip_query.h"
+
+/*
+Query Utilities
+*/
+
+
+
+void
+kmip_print_query_function_enum(int indent, enum query_function value)
+{
+    if(value == 0)
+    {
+        printf("-");
+        return;
+    }
+
+    switch(value)
+    {
+        /* KMIP 1.0 */
+        case KMIP_QUERY_OPERATIONS:
+            printf("Operations");
+            break;
+        case KMIP_QUERY_OBJECTS:
+            printf("Objects");
+            break;
+        case KMIP_QUERY_SERVER_INFORMATION:
+            printf("Server Information");
+            break;
+        case KMIP_QUERY_APPLICATION_NAMESPACES:
+            printf("Application namespaces");
+            break;
+        /* KMIP 1.1 */
+        case KMIP_QUERY_EXTENSION_LIST:
+            printf("Extension list");
+            break;
+        case KMIP_QUERY_EXTENSION_MAP:
+            printf("Extension Map");
+            break;
+        /* KMIP 1.2 */
+        case KMIP_QUERY_ATTESTATION_TYPES:
+            printf("Attestation Types");
+            break;
+        /* KMIP 1.3 */
+        case KMIP_QUERY_RNGS:
+            printf("RNGS");
+            break;
+        case KMIP_QUERY_VALIDATIONS:
+            printf("Validations");
+            break;
+        case KMIP_QUERY_PROFILES:
+            printf("Profiles");
+            break;
+        case KMIP_QUERY_CAPABILITIES:
+            printf("Capabilities");
+            break;
+        case KMIP_QUERY_CLIENT_REGISTRATION_METHODS:
+            printf("Registration Methods");
+            break;
+        /* KMIP 2.0 */
+        case KMIP_QUERY_DEFAULTS_INFORMATION:
+            printf("Defaults Information");
+            break;
+        case KMIP_QUERY_STORAGE_PROTECTION_MASKS:
+            printf("Storage Protection Masks");
+            break;
+
+        default:
+        printf("Unknown");
+        break;
+    };
+}
+
+void
+kmip_print_query_functions(int indent, QueryRequestPayload* value)
+{
+    printf("%*sQuery Functions @ %p\n", indent, "", (void *)value);
+
+    if(value != NULL)
+    {
+        printf("%*sFunctions: %zu\n", indent + 2, "", value->functions->size);
+        LinkedListItem *curr = value->functions->head;
+        size_t count = 1;
+        while(curr != NULL)
+        {
+            printf("%*sFunction: %zu: ", indent + 4, "", count);
+            int32 func = *(int32 *)curr->data;
+            kmip_print_query_function_enum(indent + 6, func);
+            printf("\n");
+
+            curr = curr->next;
+            count++;
+        }
+    }
+}
+
+/*
+void
+kmip_free_query_functions(KMIP *ctx, QueryRequestPayload* value)
+{
+    if(value != NULL)
+    {
+        if(value->functions != NULL)
+        {
+            LinkedListItem *curr = kmip_linked_list_pop(value->functions);
+            while(curr != NULL)
+            {
+                ctx->free_func(ctx->state, curr->data);
+                curr->data = NULL;
+                ctx->free_func(ctx->state, curr);
+                curr = kmip_linked_list_pop(value->functions);
+            }
+            ctx->free_func(ctx->state, value->functions);
+            value->functions = NULL;
+        }
+    }
+
+    return;
+}
+*/
+
+int
+kmip_compare_query_functions(const QueryRequestPayload* a, const QueryRequestPayload* b)
+{
+    if(a != b)
+    {
+        if((a == NULL) || (b == NULL))
+        {
+            return(KMIP_FALSE);
+        }
+
+        if((a->functions != b->functions ))
+        {
+            if((a->functions == NULL) || (b->functions == NULL))
+            {
+                return(KMIP_FALSE);
+            }
+
+            if((a->functions->size != b->functions->size))
+            {
+                return(KMIP_FALSE);
+            }
+
+            LinkedListItem *a_item = a->functions->head;
+            LinkedListItem *b_item = b->functions->head;
+            while((a_item != NULL) || (b_item != NULL))
+            {
+                if(a_item != b_item)
+                {
+                    if(!a_item || !b_item)
+                        break;
+
+                    int32 a_data = *(int32 *)a_item->data;
+                    int32 b_data = *(int32 *)b_item->data;
+                    if(a_data != b_data)
+                    {
+                        return(KMIP_FALSE);
+                    }
+                }
+
+                a_item = a_item->next;
+                b_item = b_item->next;
+            }
+
+            if(a_item != b_item)
+            {
+                return(KMIP_FALSE);
+            }
+        }
+    }
+
+    return(KMIP_TRUE);
+}
+
+int
+kmip_encode_query_functions(KMIP *ctx, const QueryRequestPayload* value)
+{
+    CHECK_ENCODE_ARGS(ctx, value);
+
+    int result = 0;
+
+    if(value->functions != NULL)
+    {
+        LinkedListItem *curr = value->functions->head;
+        while(curr != NULL)
+        {
+            result = kmip_encode_enum(ctx, KMIP_TAG_QUERY_FUNCTION, *(int32 *)curr->data);
+            CHECK_RESULT(ctx, result);
+
+            curr = curr->next;
+        }
+    }
+
+    return(KMIP_OK);
+}
+
+int
+kmip_decode_query_functions(KMIP *ctx, QueryRequestPayload* value)
+{
+    CHECK_DECODE_ARGS(ctx, value);
+    CHECK_BUFFER_FULL(ctx, 8);
+
+    int result = 0;
+    int32 tag_type = 0;
+    uint32 length = 0;
+
+    result = kmip_decode_int32_be(ctx, &tag_type);
+    CHECK_RESULT(ctx, result);
+    CHECK_TAG_TYPE(ctx, tag_type, KMIP_TAG_QUERY_FUNCTION, KMIP_TYPE_STRUCTURE);
+
+    result = kmip_decode_int32_be(ctx, &length);
+    CHECK_RESULT(ctx, result);
+    CHECK_BUFFER_FULL(ctx, length);
+
+    value->functions = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    CHECK_NEW_MEMORY(ctx, value->functions, sizeof(LinkedList), "LinkedList");
+
+    uint32 tag = kmip_peek_tag(ctx);
+    while(tag == KMIP_TAG_QUERY_FUNCTION)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        CHECK_NEW_MEMORY(ctx, item, sizeof(LinkedListItem), "LinkedListItem");
+        kmip_linked_list_enqueue(value->functions, item);
+
+        item->data = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+        CHECK_NEW_MEMORY(ctx, item->data, sizeof(int32), "Query Function");
+
+        result = kmip_decode_enum(ctx, KMIP_TAG_QUERY_FUNCTION, (int32 *)item->data);
+        CHECK_RESULT(ctx, result);
+
+        tag = kmip_peek_tag(ctx);
+    }
+
+    return(KMIP_OK);
+}
+
+/*
+
+Response Payload
+
+Item                          REQUIRED                Description
+
+ Operation                     No, MAY be repeated     Specifies an Operation that is supported by the server.
+ Object Type                   No, MAY be repeated     Specifies a Managed Object Type that is supported by the server.
+ Vendor Identification         No                      SHALL be returned if Query Server Information is requested. The Vendor Identification SHALL be a text string that uniquely identifies the vendor.
+ Server Information            No                      Contains vendor-specific information possibly be of interest to the client.
+ Application Namespace         No, MAY be repeated     Specifies an Application Namespace supported by the server.
+ Extension Information         No, MAY be repeated     SHALL be returned if Query Extension List or Query Extension Map is requested and supported by the server.
+ Attestation Type              No, MAY be repeated     Specifies an Attestation Type that is supported by the server.
+ RNG Parameters                No, MAY be repeated     Specifies the RNG that is supported by the server.
+ Profile Information           No, MAY be repeated     Specifies the Profiles that are supported by the server.
+ Validation Information        No, MAY be repeated     Specifies the validations that are supported by the server.
+ Capability Information        No, MAY be repeated     Specifies the capabilities that are supported by the server.
+ Client Registration Method    No, MAY be repeated     Specifies a Client Registration Method that is supported by the server.
+ Defaults Information          No                      Specifies the defaults that the server will use if the client omits them.
+ Protection Storage Masks      Yes                     Specifies the list of Protection Storage Mask values supported by the server. A server MAY elect to provide an empty list in the Response if it is unable or unwilling to provide this information.
+
+*/
+
+
+/*
+
+7.19 Operations
+
+A list of Operations.
+
+Object                        Encoding                REQUIRED
+Operations                    Structure
+
+Operation                     Enumeration             No, May be repeated.
+
+*/
+
+/*
+
+4.36 Object Type
+
+The Object Type of a Managed Object (e.g., public key, private key, symmetric key, etc.) SHALL be set by the server when the object is created or registered and then SHALL NOT be changed or deleted before the object is destroyed.
+
+Item                          Encoding
+Object Type                   Enumeration
+*/
+
+/*
+
+Vendor identification        Text String
+
+*/
+
+/*
+
+
+7.31 Server Information
+
+The Server Information  base object is a structure that contains a set of OPTIONAL fields that describe server information. Where a server supports returning information in a vendor-specific field for which there is an equivalent field within the structure, the server SHALL provide the standardized version of the field.
+
+Object                        Encoding                REQUIRED
+Server Information            Structure
+Server name                   Text String             No
+Server serial number          Text String             No
+Server version                Text String             No
+Server load                   Text String             No
+Product name                  Text String             No
+Build level                   Text String             No
+Build date                    Text String             No
+Cluster info                  Text String             No
+Alternative failover endpoints Text String, MAY be repeated No
+Vendor-Specific               Any, MAY be repeated    No
+
+
+*/
+
+
+/*
+application namespaces
+
+this is a list of text strings
+
+*/
+/*
+
+7.9 Extension Information
+
+An Extension Information object is a structure describing Objects with Item Tag values in the Extensions range. The Extension Name is a Text String that is used to name the Object. The Extension Tag is the Item Tag Value of the Object. The Extension Type is the Item Type Value of the Object.
+
+Object                        Encoding                REQUIRED
+Extension Information         Structure
+Extension Name                Text String             Yes
+Extension Tag                 Integer                 No
+Extension Type                Enumeration (Item Type) No
+Extension Enumeration         Integer                 No
+Extension Attribute           Boolean                 No
+Extension Parent Structure Tag Integer                 No
+Extension Description         Text String             No
+
+*/
+
+
+/*
+attestation type
+
+a list of enumerations
+
+*/
+
+/*
+7.30 RNG Parameters
+
+The RNG Parameters base object is a structure that contains a mandatory RNG Algorithm and a set of OPTIONAL fields that describe a Random Number Generator. Specific fields pertain only to certain types of RNGs.
+
+The RNG Algorithm SHALL be specified and if the algorithm implemented is unknown or the implementation does not want to provide the specific details of the RNG Algorithm then the Unspecified enumeration SHALL be used.
+
+If the cryptographic building blocks used within the RNG are known they MAY be specified in combination of the remaining fields within the RNG Parameters structure.
+
+Object                        Encoding                REQUIRED
+RNG Parameters                Structure
+RNG Algorithm                 Enumeration             Yes
+Cryptographic Algorithm       Enumeration             No
+Cryptographic Length          Integer                 No
+Hashing Algorithm             Enumeration             No
+DRBG Algorithm                Enumeration             No
+Recommended Curve             Enumeration             No
+FIPS186 Variation             Enumeration             No
+Prediction Resistance         Boolean                 No
+
+*/
+
+/*
+
+
+7.25 Profile Information
+
+The Profile Information structure contains details of the supported profiles. Specific fields MAY pertain only to certain types of profiles.
+
+Item                          Encoding                REQUIRED
+Profile Information           Structure
+Profile Name                  Enumeration             Yes
+Profile Version               Structure               No
+Server URI                    Text String             No
+Server Port                   Integer                 No
+
+
+*/
+
+/*
+
+7.35 Validation Information
+
+The Validation Information base object is a structure that contains details of a formal validation. Specific fields MAY pertain only to certain types of validations.
+
+Object                        Encoding                REQUIRED
+Validation Information        Structure
+Validation Authority Type     Enumeration             Yes
+Validation Authority Country  Text String             No
+Validation Authority URI      Text String             No
+Validation Version Major      Integer                 Yes
+Validation Version Minor      Integer                 No
+Validation Type               Enumeration             Yes
+Validation Level              Integer                 Yes
+Validation Certificate IdentifierText String          No
+Validation Certificate URI    Text String             No
+Validation Vendor URI         Text String             No
+Validation Profile            Text String, MAY be repeated No
+
+*/
+
+
+/*
+7.3 Capability Information
+
+The Capability Information base object is a structure that contains details of the supported capabilities.
+
+Object                        Encoding               REQUIRED
+
+Capability Information        Structure
+Streaming Capability          Boolean                 No
+Asynchronous Capability       Boolean                 No
+Attestation Capability        Boolean                 No
+Batch Undo Capability         Boolean                 No
+Batch Continue Capability     Boolean                 No
+Unwrap Mode                   Enumeration             No
+Destroy Action                Enumeration             No
+Shredding Algorithm           Enumeration             No
+RNG Mode                      Enumeration             No
+Quantum Safe Capability       Boolean                 No
+
+*/
+
+/*
+client registration methods
+enumeration of supported client registration methods
+
+*/
+
+/*
+7.7 Defaults Information
+
+The Defaults Information is a structure used in Query responses for values that servers will use if clients omit them from factory operations requests.
+
+Object                        Encoding                    REQUIRED
+Defaults Information          Structure
+
+Object Defaults               Structure, may be repeated  Yes
+
+*/
+
+
+/*
+
+7.27 Protection Storage Masks
+
+The Protection Storage Masks operations data object is a structure that contains an ordered collection of
+
+Protection Storage Mask selections acceptable to the client.
+
+from pykmip, its a list of integers
+
+*/
+
+
+void kmip_print_query_request_payload(int indent, QueryRequestPayload *value)
+{
+    kmip_print_query_functions(indent, value);
+}
+
+void
+kmip_free_query_request_payload(KMIP *ctx, QueryRequestPayload *value)
+{
+    if(ctx == NULL || value == NULL)
+    {
+        return;
+    }
+
+    LinkedListItem *item = kmip_linked_list_pop(value->functions);
+    while(item != NULL)
+    {
+        ctx->memset_func(item, 0, sizeof(LinkedListItem));
+        ctx->free_func(ctx->state, item);
+
+        item = kmip_linked_list_pop(value->functions);
+    }
+
+    ctx->free_func(ctx->state, value->functions);
+    value->functions = NULL;
+
+    return;
+}
+int kmip_compare_query_request_payload(const QueryRequestPayload *a, const QueryRequestPayload *b)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+int kmip_decode_query_request_payload(KMIP *ctx, QueryRequestPayload *value)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+
+int
+kmip_encode_query_request_payload(KMIP *ctx, const QueryRequestPayload *value)
+{
+    int result = 0;
+    result = kmip_encode_int32_be(ctx, TAG_TYPE(KMIP_TAG_REQUEST_PAYLOAD, KMIP_TYPE_STRUCTURE));
+    CHECK_RESULT(ctx, result);
+
+    uint8 *length_index = ctx->index;
+    uint8 *value_index = ctx->index += 4;
+
+    if(value->functions != NULL)
+    {
+        result = kmip_encode_query_functions(ctx, value);
+        CHECK_RESULT(ctx, result);
+    }
+
+    uint8 *curr_index = ctx->index;
+    ctx->index = length_index;
+
+    kmip_encode_int32_be(ctx, curr_index - value_index);
+
+    ctx->index = curr_index;
+
+    return(KMIP_OK);
+}
+
+
+int
+kmip_decode_operations(KMIP *ctx, Operations *value)
+{
+    int result = 0;
+
+    value->operation_list = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    CHECK_NEW_MEMORY(ctx, value->operation_list, sizeof(LinkedList), "LinkedList");
+
+    uint32 tag = kmip_peek_tag(ctx);
+    while(tag == KMIP_TAG_OPERATION)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        CHECK_NEW_MEMORY(ctx, item, sizeof(LinkedListItem), "LinkedListItem");
+        kmip_linked_list_enqueue(value->operation_list, item);
+
+        item->data = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+        CHECK_NEW_MEMORY(ctx, item->data, sizeof(int32), "Operation");
+
+
+        result = kmip_decode_enum(ctx, KMIP_TAG_OPERATION, (int32 *)item->data);
+        CHECK_RESULT(ctx, result);
+
+        tag = kmip_peek_tag(ctx);
+    }
+
+    return(KMIP_OK);
+}
+
+void
+kmip_print_operation_enum_2(enum all_operations value)
+{
+    #define PRINT(x)  case (x): printf(#x); break;
+
+    switch (value)
+    {
+        PRINT(KMIP_OP_CREATE_);
+        PRINT(KMIP_OP_CREATE_KEY_PAIR);
+        PRINT(KMIP_OP_REGISTER);
+        PRINT(KMIP_OP_REKEY);
+        PRINT(KMIP_OP_DERIVE_KEY);
+        PRINT(KMIP_OP_CERTIFY);
+        PRINT(KMIP_OP_RECERTIFY);
+        PRINT(KMIP_OP_LOCATE);
+        PRINT(KMIP_OP_CHECK);
+        PRINT(KMIP_OP_GET_);
+        PRINT(KMIP_OP_GET_ATTRIBUTES);
+        PRINT(KMIP_OP_GET_ATTRIBUTE_LIST);
+        PRINT(KMIP_OP_ADD_ATTRIBUTE);
+        PRINT(KMIP_OP_MODIFY_ATTRIBUTE);
+        PRINT(KMIP_OP_DELETE_ATTRIBUTE);
+        PRINT(KMIP_OP_OBTAIN_LEASE);
+        PRINT(KMIP_OP_GET_USAGE_ALLOCATION);
+        PRINT(KMIP_OP_ACTIVATE);
+        PRINT(KMIP_OP_REVOKE);
+        PRINT(KMIP_OP_DESTROY_);
+        PRINT(KMIP_OP_ARCHIVE);
+        PRINT(KMIP_OP_RECOVER);
+        PRINT(KMIP_OP_VALIDATE);
+        PRINT(KMIP_OP_QUERY_);
+        PRINT(KMIP_OP_CANCEL);
+        PRINT(KMIP_OP_POLL);
+        PRINT(KMIP_OP_NOTIFY);
+        PRINT(KMIP_OP_PUT);
+        // # KMIP 1.1
+        PRINT(KMIP_OP_REKEY_KEY_PAIR);
+        PRINT(KMIP_OP_DISCOVER_VERSIONS);
+        //# KMIP 1.2
+        PRINT(KMIP_OP_ENCRYPT);
+        PRINT(KMIP_OP_DECRYPT);
+        PRINT(KMIP_OP_SIGN);
+        PRINT(KMIP_OP_SIGNATURE_VERIFY);
+        PRINT(KMIP_OP_MAC);
+        PRINT(KMIP_OP_MAC_VERIFY);
+        PRINT(KMIP_OP_RNG_RETRIEVE);
+        PRINT(KMIP_OP_RNG_SEED);
+        PRINT(KMIP_OP_HASH);
+        PRINT(KMIP_OP_CREATE_SPLIT_KEY);
+        PRINT(KMIP_OP_JOIN_SPLIT_KEY);
+        // # KMIP 1.4
+        PRINT(KMIP_OP_IMPORT);
+        PRINT(KMIP_OP_EXPORT);
+        // # KMIP 2.0
+        PRINT(KMIP_OP_LOG);
+        PRINT(KMIP_OP_LOGIN);
+        PRINT(KMIP_OP_LOGOUT);
+        PRINT(KMIP_OP_DELEGATED_LOGIN);
+        PRINT(KMIP_OP_ADJUST_ATTRIBUTE);
+        PRINT(KMIP_OP_SET_ATTRIBUTE);
+        PRINT(KMIP_OP_SET_ENDPOINT_ROLE);
+        PRINT(KMIP_OP_PKCS_11);
+        PRINT(KMIP_OP_INTEROP);
+        PRINT(KMIP_OP_REPROVISION);
+
+        default:
+            printf("Unknown");
+            break;
+    }
+}
+
+void
+kmip_free_operations(KMIP *ctx, Operations *value)
+{
+
+    if(value != NULL)
+    {
+        if(value->operation_list != NULL)
+        {
+            LinkedListItem *curr = kmip_linked_list_pop(value->operation_list);
+            while(curr != NULL)
+            {
+                ctx->free_func(ctx->state, curr->data);
+                curr->data = NULL;
+                ctx->free_func(ctx->state, curr);
+                curr = kmip_linked_list_pop(value->operation_list);
+            }
+            ctx->free_func(ctx->state, value->operation_list);
+            value->operation_list = NULL;
+        }
+    }
+
+    return;
+}
+
+void
+kmip_print_operations(int indent, Operations *value)
+{
+    printf("%*sOperations @ %p\n", indent, "", (void *)value);
+
+    if(value != NULL)
+    {
+        printf("%*sOperations: %zu\n", indent + 2, "", value->operation_list->size);
+        LinkedListItem *curr = value->operation_list->head;
+        size_t count = 1;
+        while(curr != NULL)
+        {
+            printf("%*sOperation: %zu: ", indent + 4, "", count);
+            int32 oper = *(int32 *)curr->data;
+            kmip_print_operation_enum_2(oper);
+            printf("\n");
+
+            curr = curr->next;
+            count++;
+        }
+    }
+}
+
+void
+kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, int max_ops)
+{
+    if(value != NULL)
+    {
+        *ops_size = value->operation_list->size;
+
+        LinkedListItem *curr = value->operation_list->head;
+        size_t idx = 0;
+        while(curr != NULL && idx < max_ops )
+        {
+            ops[idx] = *(int32 *)curr->data;
+            curr = curr->next;
+            idx++;
+        }
+    }
+}
+
+void
+kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, int max_objs)
+{
+    if(value != NULL)
+    {
+        *objs_size = value->object_list->size;
+
+        LinkedListItem *curr = value->object_list->head;
+        size_t idx = 0;
+        while(curr != NULL && idx < max_objs )
+        {
+            objs[idx] = *(int32 *)curr->data;
+            curr = curr->next;
+            idx++;
+        }
+    }
+}
+
+void
+kmip_print_object_types(int indent, ObjectTypes* value)
+{
+    printf("%*sObjects @ %p\n", indent, "", (void *)value);
+
+    if(value != NULL)
+    {
+        printf("%*sObjects: %zu\n", indent + 2, "", value->object_list->size);
+        LinkedListItem *curr = value->object_list->head;
+        size_t count = 1;
+        while(curr != NULL)
+        {
+            printf("%*sObject: %zu: ", indent + 4, "", count);
+            int32 obj = *(int32 *)curr->data;
+            kmip_print_object_type_enum(obj);
+            printf("\n");
+
+            curr = curr->next;
+            count++;
+        }
+    }
+}
+
+void
+kmip_free_objects(KMIP *ctx, ObjectTypes* value)
+{
+    if(value != NULL)
+    {
+        if(value->object_list != NULL)
+        {
+            LinkedListItem *curr = kmip_linked_list_pop(value->object_list);
+            while(curr != NULL)
+            {
+                ctx->free_func(ctx->state, curr->data);
+                curr->data = NULL;
+                ctx->free_func(ctx->state, curr);
+                curr = kmip_linked_list_pop(value->object_list);
+            }
+            ctx->free_func(ctx->state, value->object_list);
+            value->object_list = NULL;
+        }
+    }
+
+    return;
+}
+
+int
+kmip_decode_object_types(KMIP *ctx, ObjectTypes *value)
+{
+    int result = 0;
+
+    value->object_list = ctx->calloc_func(ctx->state, 1, sizeof(LinkedList));
+    CHECK_NEW_MEMORY(ctx, value->object_list, sizeof(LinkedList), "LinkedList");
+
+    uint32 tag = kmip_peek_tag(ctx);
+    while(tag == KMIP_TAG_OBJECT_TYPE)
+    {
+        LinkedListItem *item = ctx->calloc_func(ctx->state, 1, sizeof(LinkedListItem));
+        CHECK_NEW_MEMORY(ctx, item, sizeof(LinkedListItem), "LinkedListItem");
+        kmip_linked_list_enqueue(value->object_list, item);
+
+        item->data = ctx->calloc_func(ctx->state, 1, sizeof(int32));
+        CHECK_NEW_MEMORY(ctx, item->data, sizeof(int32), "Object");
+
+        result = kmip_decode_enum(ctx, KMIP_TAG_OBJECT_TYPE, (int32 *)item->data);
+        CHECK_RESULT(ctx, result);
+
+        tag = kmip_peek_tag(ctx);
+    }
+
+    return(KMIP_OK);
+}
+
+
+void
+kmip_free_server_information(KMIP* ctx, ServerInformation* value)
+{
+    kmip_free_text_string(ctx, value->server_name);
+    kmip_free_text_string(ctx, value->server_serial_number);
+    kmip_free_text_string(ctx, value->server_version);
+    kmip_free_text_string(ctx, value->server_load);
+    kmip_free_text_string(ctx, value->product_name);
+    kmip_free_text_string(ctx, value->build_level);
+    kmip_free_text_string(ctx, value->build_date);
+    kmip_free_text_string(ctx, value->cluster_info);
+}
+
+int
+kmip_decode_server_information(KMIP *ctx, ServerInformation *value)
+{
+    CHECK_BUFFER_FULL(ctx, 8);
+
+    int result = 0;
+    int32 tag_type = 0;
+    uint32 length = 0;
+
+    kmip_decode_int32_be(ctx, &tag_type);
+    CHECK_TAG_TYPE(ctx, tag_type, KMIP_TAG_SERVER_INFORMATION, KMIP_TYPE_STRUCTURE);
+
+    kmip_decode_int32_be(ctx, &length);
+    CHECK_BUFFER_FULL(ctx, length);
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_SERVER_NAME))
+    {
+        value->server_name = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->server_name, sizeof(TextString), "ServerName text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_SERVER_NAME, value->server_name);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_SERVER_SERIAL_NUMBER))
+    {
+        value->server_serial_number = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->server_serial_number, sizeof(TextString), "ServerSerialNumber text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_SERVER_SERIAL_NUMBER, value->server_serial_number);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_SERVER_VERSION))
+    {
+        value->server_version = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->server_version, sizeof(TextString), "ServerVersion text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_SERVER_VERSION, value->server_version);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_SERVER_LOAD))
+    {
+        value->server_load = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->server_load, sizeof(TextString), "ServerLoad text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_SERVER_LOAD, value->server_load);
+        CHECK_RESULT(ctx, result);
+    }
+
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_PRODUCT_NAME))
+    {
+        value->product_name = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->product_name, sizeof(TextString), "ProductName text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_PRODUCT_NAME, value->product_name);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_BUILD_LEVEL))
+    {
+        value->build_level = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->build_level, sizeof(TextString), "BuildLevel text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_BUILD_LEVEL, value->build_level);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_BUILD_DATE))
+    {
+        value->build_date = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->build_date, sizeof(TextString), "BuildDate text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_BUILD_DATE, value->build_date);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_CLUSTER_INFO))
+    {
+        value->cluster_info = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->cluster_info, sizeof(TextString), "ClusterInfo text string");
+
+        result = kmip_decode_text_string(ctx, KMIP_TAG_CLUSTER_INFO, value->cluster_info);
+        CHECK_RESULT(ctx, result);
+    }
+
+    return(KMIP_OK);
+}
+
+void
+kmip_print_server_information(int indent, ServerInformation* value)
+{
+    printf("%*sServer Information @ %p\n", indent, "", (void *)value);
+
+    if(value != NULL)
+    {
+        kmip_print_text_string(indent + 2, "Server Name", value->server_name);
+        kmip_print_text_string(indent + 2, "Server Serial Number", value->server_serial_number);
+        kmip_print_text_string(indent + 2, "Server Version", value->server_version);
+        kmip_print_text_string(indent + 2, "Server Load", value->server_load);
+        kmip_print_text_string(indent + 2, "Product Name", value->product_name);
+        kmip_print_text_string(indent + 2, "Build Llevel", value->build_level);
+        kmip_print_text_string(indent + 2, "Build Date", value->build_date);
+        kmip_print_text_string(indent + 2, "Cluster info", value->cluster_info);
+    }
+}
+
+
+void kmip_print_query_response_payload(int indent, QueryResponsePayload *value)
+{
+    kmip_print_operations(indent, value->operations);
+    kmip_print_object_types(indent, value->objects);
+    kmip_print_text_string(indent, "Vendor ID", value->vendor_identification);
+    kmip_print_server_information(indent, value->server_information);
+}
+
+void kmip_free_query_response_payload(KMIP *ctx, QueryResponsePayload *value)
+{
+    if (value->operations)
+    {
+        kmip_free_operations(ctx, value->operations);
+        ctx->free_func(ctx->state, value->operations);
+        value->operations = NULL;
+    }
+    if (value->objects)
+    {
+        kmip_free_objects(ctx, value->objects);
+        ctx->free_func(ctx->state, value->objects);
+        value->objects = NULL;
+    }
+
+    if (value->vendor_identification)
+    {
+        kmip_free_text_string(ctx, value->vendor_identification);
+        ctx->free_func(ctx->state, value->vendor_identification);
+        value->vendor_identification = NULL;
+    }
+
+    if (value->server_information)
+    {
+        kmip_free_server_information(ctx, value->server_information);
+        ctx->free_func(ctx->state, value->server_information);
+        value->server_information = NULL;
+    }
+}
+
+int kmip_compare_query_response_payload(const QueryResponsePayload *a, const QueryResponsePayload *b)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+
+int kmip_decode_query_response_payload(KMIP *ctx, QueryResponsePayload *value)
+{
+    int result = 0;
+
+    int32 tag_type = 0;
+    uint32 length = 0;
+
+    kmip_decode_int32_be(ctx, &tag_type);
+    CHECK_TAG_TYPE(ctx, tag_type, KMIP_TAG_RESPONSE_PAYLOAD, KMIP_TYPE_STRUCTURE);
+
+    kmip_decode_int32_be(ctx, &length);
+    CHECK_BUFFER_FULL(ctx, length);
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_OPERATION))
+    {
+        value->operations = ctx->calloc_func(ctx->state, 1, sizeof(Operations));
+        CHECK_NEW_MEMORY(ctx, value->operations, sizeof(Operations), "Operations");
+        result = kmip_decode_operations(ctx, value->operations);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_OBJECT_TYPE))
+    {
+        value->objects = ctx->calloc_func(ctx->state, 1, sizeof(ObjectTypes));
+        CHECK_NEW_MEMORY(ctx, value->objects, sizeof(ObjectTypes), "Object_Types");
+        result = kmip_decode_object_types(ctx, value->objects);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_VENDOR_IDENTIFICATION))
+    {
+        value->vendor_identification = ctx->calloc_func(ctx->state, 1, sizeof(TextString));
+        CHECK_NEW_MEMORY(ctx, value->vendor_identification, sizeof(TextString), "Vendor Identifier text string");
+        result = kmip_decode_text_string(ctx, KMIP_TAG_VENDOR_IDENTIFICATION, (TextString*)value->vendor_identification);
+        CHECK_RESULT(ctx, result);
+    }
+
+    if(kmip_is_tag_next(ctx, KMIP_TAG_SERVER_INFORMATION))
+    {
+        value->server_information = ctx->calloc_func(ctx->state, 1, sizeof(ServerInformation));
+        CHECK_NEW_MEMORY(ctx, value->server_information, sizeof(ServerInformation), "Server Information");
+        result = kmip_decode_server_information(ctx, value->server_information);
+        CHECK_RESULT(ctx, result);
+    }
+
+    return(KMIP_OK);
+}
+
+int
+kmip_encode_query_response_payload(KMIP *ctx, const QueryResponsePayload *value)
+{
+    return(KMIP_NOT_IMPLEMENTED);
+}
+
+void
+kmip_copy_query_result(QueryResponse* query_result, QueryResponsePayload *pld)
+{
+    if(pld != NULL)
+    {
+        kmip_copy_operations(query_result->operations, &query_result->operations_size, pld->operations, MAX_QUERY_OPS);
+        kmip_copy_objects(query_result->objects, &query_result->objects_size, pld->objects, MAX_QUERY_OBJS);
+
+        if(pld->vendor_identification)
+        {
+            kmip_copy_textstring(query_result->vendor_identification, pld->vendor_identification, sizeof(query_result->vendor_identification)-1);
+        }
+
+        if(pld->server_information)
+        {
+            ServerInformation* srv = pld->server_information;
+            query_result->server_information_valid = 1;
+            kmip_copy_textstring(query_result->server_name, srv->server_name, MAX_QUERY_LEN-1);
+            kmip_copy_textstring(query_result->server_serial_number, srv->server_serial_number, MAX_QUERY_LEN-1);
+            kmip_copy_textstring(query_result->server_version, srv->server_version, MAX_QUERY_LEN-1);
+            kmip_copy_textstring(query_result->server_load, srv->server_load, MAX_QUERY_LEN-1);
+            kmip_copy_textstring(query_result->product_name, srv->product_name, MAX_QUERY_LEN-1);
+            kmip_copy_textstring(query_result->build_level, srv->build_level, MAX_QUERY_LEN-1);
+            kmip_copy_textstring(query_result->build_date, srv->build_date, MAX_QUERY_LEN-1);
+        }
+    }
+}
+

--- a/kmip_query.c
+++ b/kmip_query.c
@@ -22,11 +22,11 @@ Query Utilities
 
 
 void
-kmip_print_query_function_enum(int indent, enum query_function value)
+kmip_print_query_function_enum(FILE* f, int indent, enum query_function value)
 {
     if(value == 0)
     {
-        printf("-");
+        fprintf(f, "%*s-", indent, "");
         return;
     }
 
@@ -34,74 +34,74 @@ kmip_print_query_function_enum(int indent, enum query_function value)
     {
         /* KMIP 1.0 */
         case KMIP_QUERY_OPERATIONS:
-            printf("Operations");
+            fprintf(f, "%*sOperations", indent, "");
             break;
         case KMIP_QUERY_OBJECTS:
-            printf("Objects");
+            fprintf(f, "%*sObjects", indent, "");
             break;
         case KMIP_QUERY_SERVER_INFORMATION:
-            printf("Server Information");
+            fprintf(f, "%*sServer Information", indent, "");
             break;
         case KMIP_QUERY_APPLICATION_NAMESPACES:
-            printf("Application namespaces");
+            fprintf(f, "%*sApplication namespaces", indent, "");
             break;
         /* KMIP 1.1 */
         case KMIP_QUERY_EXTENSION_LIST:
-            printf("Extension list");
+            fprintf(f, "%*sExtension list", indent, "");
             break;
         case KMIP_QUERY_EXTENSION_MAP:
-            printf("Extension Map");
+            fprintf(f, "%*sExtension Map", indent, "");
             break;
         /* KMIP 1.2 */
         case KMIP_QUERY_ATTESTATION_TYPES:
-            printf("Attestation Types");
+            fprintf(f, "%*sAttestation Types", indent, "");
             break;
         /* KMIP 1.3 */
         case KMIP_QUERY_RNGS:
-            printf("RNGS");
+            fprintf(f, "%*sRNGS", indent, "");
             break;
         case KMIP_QUERY_VALIDATIONS:
-            printf("Validations");
+            fprintf(f, "%*sValidations", indent, "");
             break;
         case KMIP_QUERY_PROFILES:
-            printf("Profiles");
+            fprintf(f, "%*sProfiles", indent, "");
             break;
         case KMIP_QUERY_CAPABILITIES:
-            printf("Capabilities");
+            fprintf(f, "%*sCapabilities", indent, "");
             break;
         case KMIP_QUERY_CLIENT_REGISTRATION_METHODS:
-            printf("Registration Methods");
+            fprintf(f, "%*sRegistration Methods", indent, "");
             break;
         /* KMIP 2.0 */
         case KMIP_QUERY_DEFAULTS_INFORMATION:
-            printf("Defaults Information");
+            fprintf(f, "%*sDefaults Information", indent, "");
             break;
         case KMIP_QUERY_STORAGE_PROTECTION_MASKS:
-            printf("Storage Protection Masks");
+            fprintf(f, "%*sStorage Protection Masks", indent, "");
             break;
 
         default:
-        printf("Unknown");
+        fprintf(f, "%*sUnknown", indent, "");
         break;
     };
 }
 
 void
-kmip_print_query_functions(int indent, QueryRequestPayload* value)
+kmip_print_query_functions(FILE* f, int indent, QueryRequestPayload* value)
 {
-    printf("%*sQuery Functions @ %p\n", indent, "", (void *)value);
+    fprintf(f, "%*sQuery Functions @ %p\n", indent, "", (void *)value);
 
     if(value != NULL)
     {
-        printf("%*sFunctions: %zu\n", indent + 2, "", value->functions->size);
+        fprintf(f, "%*sFunctions: %zu\n", indent + 2, "", value->functions->size);
         LinkedListItem *curr = value->functions->head;
         size_t count = 1;
         while(curr != NULL)
         {
-            printf("%*sFunction: %zu: ", indent + 4, "", count);
+            fprintf(f, "%*sFunction: %zu: ", indent + 4, "", count);
             int32 func = *(int32 *)curr->data;
-            kmip_print_query_function_enum(indent + 6, func);
-            printf("\n");
+            kmip_print_query_function_enum(f, indent + 6, func);
+            fprintf(f, "\n");
 
             curr = curr->next;
             count++;
@@ -473,9 +473,9 @@ from pykmip, its a list of integers
 */
 
 
-void kmip_print_query_request_payload(int indent, QueryRequestPayload *value)
+void kmip_print_query_request_payload(FILE* f, int indent, QueryRequestPayload *value)
 {
-    kmip_print_query_functions(indent, value);
+    kmip_print_query_functions(f, indent, value);
 }
 
 void
@@ -502,10 +502,14 @@ kmip_free_query_request_payload(KMIP *ctx, QueryRequestPayload *value)
 }
 int kmip_compare_query_request_payload(const QueryRequestPayload *a, const QueryRequestPayload *b)
 {
+    (void) a;
+    (void) b;
     return(KMIP_NOT_IMPLEMENTED);
 }
 int kmip_decode_query_request_payload(KMIP *ctx, QueryRequestPayload *value)
 {
+    (void) ctx;
+    (void) value;
     return(KMIP_NOT_IMPLEMENTED);
 }
 
@@ -565,9 +569,9 @@ kmip_decode_operations(KMIP *ctx, Operations *value)
 }
 
 void
-kmip_print_operation_enum_2(enum all_operations value)
+kmip_print_operation_enum_2(FILE* f, enum all_operations value)
 {
-    #define PRINT(x)  case (x): printf(#x); break;
+    #define PRINT(x)  case (x): fprintf(f, #x); break;
 
     switch (value)
     {
@@ -630,7 +634,7 @@ kmip_print_operation_enum_2(enum all_operations value)
         PRINT(KMIP_OP_REPROVISION);
 
         default:
-            printf("Unknown");
+            fprintf(f, "Unknown");
             break;
     }
 }
@@ -660,21 +664,21 @@ kmip_free_operations(KMIP *ctx, Operations *value)
 }
 
 void
-kmip_print_operations(int indent, Operations *value)
+kmip_print_operations(FILE* f, int indent, Operations *value)
 {
-    printf("%*sOperations @ %p\n", indent, "", (void *)value);
+    fprintf(f, "%*sOperations @ %p\n", indent, "", (void *)value);
 
     if(value != NULL)
     {
-        printf("%*sOperations: %zu\n", indent + 2, "", value->operation_list->size);
+        fprintf(f, "%*sOperations: %zu\n", indent + 2, "", value->operation_list->size);
         LinkedListItem *curr = value->operation_list->head;
         size_t count = 1;
         while(curr != NULL)
         {
-            printf("%*sOperation: %zu: ", indent + 4, "", count);
+            fprintf(f, "%*sOperation: %zu: ", indent + 4, "", count);
             int32 oper = *(int32 *)curr->data;
-            kmip_print_operation_enum_2(oper);
-            printf("\n");
+            kmip_print_operation_enum_2(f, oper);
+            fprintf(f, "\n");
 
             curr = curr->next;
             count++;
@@ -683,7 +687,7 @@ kmip_print_operations(int indent, Operations *value)
 }
 
 void
-kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, int max_ops)
+kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, unsigned max_ops)
 {
     if(value != NULL)
     {
@@ -701,7 +705,7 @@ kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, int max_ops
 }
 
 void
-kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, int max_objs)
+kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, unsigned max_objs)
 {
     if(value != NULL)
     {
@@ -719,21 +723,21 @@ kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, int max_obj
 }
 
 void
-kmip_print_object_types(int indent, ObjectTypes* value)
+kmip_print_object_types(FILE* f, int indent, ObjectTypes* value)
 {
-    printf("%*sObjects @ %p\n", indent, "", (void *)value);
+    fprintf(f, "%*sObjects @ %p\n", indent, "", (void *)value);
 
     if(value != NULL)
     {
-        printf("%*sObjects: %zu\n", indent + 2, "", value->object_list->size);
+        fprintf(f, "%*sObjects: %zu\n", indent + 2, "", value->object_list->size);
         LinkedListItem *curr = value->object_list->head;
         size_t count = 1;
         while(curr != NULL)
         {
-            printf("%*sObject: %zu: ", indent + 4, "", count);
+            fprintf(f, "%*sObject: %zu: ", indent + 4, "", count);
             int32 obj = *(int32 *)curr->data;
-            kmip_print_object_type_enum(obj);
-            printf("\n");
+            kmip_print_object_type_enum(f, obj);
+            fprintf(f, "\n");
 
             curr = curr->next;
             count++;
@@ -897,30 +901,30 @@ kmip_decode_server_information(KMIP *ctx, ServerInformation *value)
 }
 
 void
-kmip_print_server_information(int indent, ServerInformation* value)
+kmip_print_server_information(FILE* f, int indent, ServerInformation* value)
 {
-    printf("%*sServer Information @ %p\n", indent, "", (void *)value);
+    fprintf(f,"%*sServer Information @ %p\n", indent, "", (void *)value);
 
     if(value != NULL)
     {
-        kmip_print_text_string(indent + 2, "Server Name", value->server_name);
-        kmip_print_text_string(indent + 2, "Server Serial Number", value->server_serial_number);
-        kmip_print_text_string(indent + 2, "Server Version", value->server_version);
-        kmip_print_text_string(indent + 2, "Server Load", value->server_load);
-        kmip_print_text_string(indent + 2, "Product Name", value->product_name);
-        kmip_print_text_string(indent + 2, "Build Llevel", value->build_level);
-        kmip_print_text_string(indent + 2, "Build Date", value->build_date);
-        kmip_print_text_string(indent + 2, "Cluster info", value->cluster_info);
+        kmip_print_text_string(f,indent + 2, "Server Name", value->server_name);
+        kmip_print_text_string(f,indent + 2, "Server Serial Number", value->server_serial_number);
+        kmip_print_text_string(f,indent + 2, "Server Version", value->server_version);
+        kmip_print_text_string(f,indent + 2, "Server Load", value->server_load);
+        kmip_print_text_string(f,indent + 2, "Product Name", value->product_name);
+        kmip_print_text_string(f,indent + 2, "Build Llevel", value->build_level);
+        kmip_print_text_string(f,indent + 2, "Build Date", value->build_date);
+        kmip_print_text_string(f,indent + 2, "Cluster info", value->cluster_info);
     }
 }
 
 
-void kmip_print_query_response_payload(int indent, QueryResponsePayload *value)
+void kmip_print_query_response_payload(FILE* f, int indent, QueryResponsePayload *value)
 {
-    kmip_print_operations(indent, value->operations);
-    kmip_print_object_types(indent, value->objects);
-    kmip_print_text_string(indent, "Vendor ID", value->vendor_identification);
-    kmip_print_server_information(indent, value->server_information);
+    kmip_print_operations(f,indent, value->operations);
+    kmip_print_object_types(f,indent, value->objects);
+    kmip_print_text_string(f,indent, "Vendor ID", value->vendor_identification);
+    kmip_print_server_information(f,indent, value->server_information);
 }
 
 void kmip_free_query_response_payload(KMIP *ctx, QueryResponsePayload *value)
@@ -955,6 +959,8 @@ void kmip_free_query_response_payload(KMIP *ctx, QueryResponsePayload *value)
 
 int kmip_compare_query_response_payload(const QueryResponsePayload *a, const QueryResponsePayload *b)
 {
+    (void) a;
+    (void) b;
     return(KMIP_NOT_IMPLEMENTED);
 }
 
@@ -1009,6 +1015,8 @@ int kmip_decode_query_response_payload(KMIP *ctx, QueryResponsePayload *value)
 int
 kmip_encode_query_response_payload(KMIP *ctx, const QueryResponsePayload *value)
 {
+    (void) ctx;
+    (void) value;
     return(KMIP_NOT_IMPLEMENTED);
 }
 

--- a/kmip_query.h
+++ b/kmip_query.h
@@ -149,27 +149,27 @@ typedef struct query_response
     char             cluster_info[MAX_QUERY_LEN];
 } QueryResponse;
 
-void kmip_print_query_request_payload(int, QueryRequestPayload *);
+void kmip_print_query_request_payload(FILE*, int, QueryRequestPayload *);
 void kmip_free_query_request_payload(KMIP *, QueryRequestPayload *);
 int kmip_compare_query_request_payload(const QueryRequestPayload *, const QueryRequestPayload *);
 int kmip_encode_query_request_payload(KMIP *, const QueryRequestPayload *);
 int kmip_decode_query_request_payload(KMIP *, QueryRequestPayload *);
 
-void kmip_print_query_response_payload(int, QueryResponsePayload *);
+void kmip_print_query_response_payload(FILE*, int, QueryResponsePayload *);
 void kmip_free_query_response_payload(KMIP *, QueryResponsePayload *);
 int kmip_compare_query_response_payload(const QueryResponsePayload *, const QueryResponsePayload *);
 int kmip_encode_query_response_payload(KMIP *, const QueryResponsePayload *);
 int kmip_decode_query_response_payload(KMIP *, QueryResponsePayload *);
 
-void kmip_print_query_function_enum(int indent, enum query_function value);
-void kmip_print_query_functions(int indent, QueryRequestPayload* value);
+void kmip_print_query_function_enum(FILE*, int indent, enum query_function value);
+void kmip_print_query_functions(FILE*, int indent, QueryRequestPayload* value);
 void kmip_free_query_functions(KMIP *ctx, QueryRequestPayload* value);
 int  kmip_compare_query_functions(const QueryRequestPayload* a, const QueryRequestPayload* b);
 int  kmip_encode_query_functions(KMIP *ctx, const QueryRequestPayload* value);
 int  kmip_decode_query_functions(KMIP *ctx, QueryRequestPayload* value);
 
 
-void kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, int max_ops);
-void kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, int max_objs);
+void kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, unsigned max_ops);
+void kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, unsigned max_objs);
 void kmip_copy_query_result(QueryResponse* query_result, QueryResponsePayload *pld);
 

--- a/kmip_query.h
+++ b/kmip_query.h
@@ -1,0 +1,175 @@
+/* Copyright (c) 2018 The Johns Hopkins University/Applied Physics Laboratory
+ * All Rights Reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
+#include <openssl/ssl.h>      // for BIO
+
+
+enum all_operations
+{
+    // # KMIP 1.0
+    KMIP_OP_CREATE_               = 0x01,
+    KMIP_OP_CREATE_KEY_PAIR      = 0x02,
+    KMIP_OP_REGISTER             = 0x03,
+    KMIP_OP_REKEY                = 0x04,
+    KMIP_OP_DERIVE_KEY           = 0x05,
+    KMIP_OP_CERTIFY              = 0x06,
+    KMIP_OP_RECERTIFY            = 0x07,
+    KMIP_OP_LOCATE_              = 0x08,
+    KMIP_OP_CHECK                = 0x09,
+    KMIP_OP_GET_                  = 0x0A,
+    KMIP_OP_GET_ATTRIBUTES       = 0x0B,
+    KMIP_OP_GET_ATTRIBUTE_LIST   = 0x0C,
+    KMIP_OP_ADD_ATTRIBUTE        = 0x0D,
+    KMIP_OP_MODIFY_ATTRIBUTE     = 0x0E,
+    KMIP_OP_DELETE_ATTRIBUTE     = 0x0F,
+    KMIP_OP_OBTAIN_LEASE         = 0x10,
+    KMIP_OP_GET_USAGE_ALLOCATION = 0x11,
+    KMIP_OP_ACTIVATE             = 0x12,
+    KMIP_OP_REVOKE               = 0x13,
+    KMIP_OP_DESTROY_              = 0x14,
+    KMIP_OP_ARCHIVE              = 0x15,
+    KMIP_OP_RECOVER              = 0x16,
+    KMIP_OP_VALIDATE             = 0x17,
+    KMIP_OP_QUERY_                = 0x18,
+    KMIP_OP_CANCEL               = 0x19,
+    KMIP_OP_POLL                 = 0x1A,
+    KMIP_OP_NOTIFY               = 0x1B,
+    KMIP_OP_PUT                  = 0x1C,
+    // # KMIP 1.1
+    KMIP_OP_REKEY_KEY_PAIR       = 0x1D,
+    KMIP_OP_DISCOVER_VERSIONS    = 0x1E,
+    //# KMIP 1.2
+    KMIP_OP_ENCRYPT              = 0x1F,
+    KMIP_OP_DECRYPT              = 0x20,
+    KMIP_OP_SIGN                 = 0x21,
+    KMIP_OP_SIGNATURE_VERIFY     = 0x22,
+    KMIP_OP_MAC                  = 0x23,
+    KMIP_OP_MAC_VERIFY           = 0x24,
+    KMIP_OP_RNG_RETRIEVE         = 0x25,
+    KMIP_OP_RNG_SEED             = 0x26,
+    KMIP_OP_HASH                 = 0x27,
+    KMIP_OP_CREATE_SPLIT_KEY     = 0x28,
+    KMIP_OP_JOIN_SPLIT_KEY       = 0x29,
+    // # KMIP 1.4
+    KMIP_OP_IMPORT               = 0x2A,
+    KMIP_OP_EXPORT               = 0x2B,
+    // # KMIP 2.0
+    KMIP_OP_LOG                  = 0x2C,
+    KMIP_OP_LOGIN                = 0x2D,
+    KMIP_OP_LOGOUT               = 0x2E,
+    KMIP_OP_DELEGATED_LOGIN      = 0x2F,
+    KMIP_OP_ADJUST_ATTRIBUTE     = 0x30,
+    KMIP_OP_SET_ATTRIBUTE        = 0x31,
+    KMIP_OP_SET_ENDPOINT_ROLE    = 0x32,
+    KMIP_OP_PKCS_11              = 0x33,
+    KMIP_OP_INTEROP              = 0x34,
+    KMIP_OP_REPROVISION          = 0x35,
+};
+
+typedef struct operations
+{
+    LinkedList *operation_list;
+} Operations;
+
+typedef struct object_types
+{
+    LinkedList *object_list;
+} ObjectTypes;
+
+typedef struct server_information
+{
+    TextString* server_name;
+    TextString* server_serial_number;
+    TextString* server_version;
+    TextString* server_load;
+    TextString* product_name;
+    TextString* build_level;
+    TextString* build_date;
+    TextString* cluster_info;
+ // LinkedList* alternative_failover_endpoints;   MAY be repeated
+ // Vendor-Specific               Any, MAY be repeated
+} ServerInformation;
+
+
+/*
+typedef struct application_namespaces
+{
+    LinkedList *app_namespace_list;
+} ApplicationNamespaces;
+*/
+
+typedef struct query_request_payload
+{
+    LinkedList *functions;
+} QueryRequestPayload;
+
+typedef struct query_response_payload
+{
+    Operations*             operations;              // Specifies an Operation that is supported by the server.
+    ObjectTypes*            objects;                 // Specifies a Managed Object Type that is supported by the server.
+    TextString*             vendor_identification;   // SHALL be returned if Query Server Information is requested. The Vendor Identification SHALL be a text string that uniquely identifies the vendor.
+    ServerInformation*      server_information;      // Contains vendor-specific information possibly be of interest to the client.
+ // ApplicationNamespaces*  application_namespaces;  // Specifies an Application Namespace supported by the server.
+ // Extension Information         No, MAY be repeated  // SHALL be returned if Query Extension List or Query Extension Map is requested and supported by the server.
+ // Attestation Type              No, MAY be repeated  // Specifies an Attestation Type that is supported by the server.
+ // RNG Parameters                No, MAY be repeated  // Specifies the RNG that is supported by the server.
+ // Profile Information           No, MAY be repeated  // Specifies the Profiles that are supported by the server.
+ // Validation Information        No, MAY be repeated  // Specifies the validations that are supported by the server.
+ // Capability Information        No, MAY be repeated  // Specifies the capabilities that are supported by the server.
+ // Client Registration Method    No, MAY be repeated  // Specifies a Client Registration Method that is supported by the server.
+ // Defaults Information          No                   // Specifies the defaults that the server will use if the client omits them.
+ // Protection Storage Masks      Yes                  // Specifies the list of Protection Storage Mask values supported by the server. A server MAY elect to provide an empty list in the Response if it is unable or unwilling to provide this information.
+} QueryResponsePayload;
+
+
+#define MAX_QUERY_LEN    128
+#define MAX_QUERY_OPS   0x40
+#define MAX_QUERY_OBJS  0x20
+
+typedef struct query_response
+{
+    size_t           operations_size;
+    int              operations[MAX_QUERY_OPS];
+    size_t           objects_size;
+    int              objects[MAX_QUERY_OBJS];
+    char             vendor_identification[MAX_QUERY_LEN];
+    bool32           server_information_valid;
+    char             server_name[MAX_QUERY_LEN];
+    char             server_serial_number[MAX_QUERY_LEN];
+    char             server_version[MAX_QUERY_LEN];
+    char             server_load[MAX_QUERY_LEN];
+    char             product_name[MAX_QUERY_LEN];
+    char             build_level[MAX_QUERY_LEN];
+    char             build_date[MAX_QUERY_LEN];
+    char             cluster_info[MAX_QUERY_LEN];
+} QueryResponse;
+
+void kmip_print_query_request_payload(int, QueryRequestPayload *);
+void kmip_free_query_request_payload(KMIP *, QueryRequestPayload *);
+int kmip_compare_query_request_payload(const QueryRequestPayload *, const QueryRequestPayload *);
+int kmip_encode_query_request_payload(KMIP *, const QueryRequestPayload *);
+int kmip_decode_query_request_payload(KMIP *, QueryRequestPayload *);
+
+void kmip_print_query_response_payload(int, QueryResponsePayload *);
+void kmip_free_query_response_payload(KMIP *, QueryResponsePayload *);
+int kmip_compare_query_response_payload(const QueryResponsePayload *, const QueryResponsePayload *);
+int kmip_encode_query_response_payload(KMIP *, const QueryResponsePayload *);
+int kmip_decode_query_response_payload(KMIP *, QueryResponsePayload *);
+
+void kmip_print_query_function_enum(int indent, enum query_function value);
+void kmip_print_query_functions(int indent, QueryRequestPayload* value);
+void kmip_free_query_functions(KMIP *ctx, QueryRequestPayload* value);
+int  kmip_compare_query_functions(const QueryRequestPayload* a, const QueryRequestPayload* b);
+int  kmip_encode_query_functions(KMIP *ctx, const QueryRequestPayload* value);
+int  kmip_decode_query_functions(KMIP *ctx, QueryRequestPayload* value);
+
+
+void kmip_copy_operations(int ops[], size_t* ops_size, Operations *value, int max_ops);
+void kmip_copy_objects(int objs[], size_t* objs_size, ObjectTypes *value, int max_objs);
+void kmip_copy_query_result(QueryResponse* query_result, QueryResponsePayload *pld);
+

--- a/ssl_connect.c
+++ b/ssl_connect.c
@@ -1,0 +1,171 @@
+#include <stdbool.h>
+#include <openssl/err.h>
+#include "ssl_connect.h"
+
+int  ssl_reused = 0;
+int  ssl_error = 0;
+int  ssl_error_type = 0;
+char ssl_saved_error[512] = "";
+
+//------------------------------------------------------------------------------
+void ssl_initialize()
+{
+    SSL_library_init();
+}
+
+// we don't really need to verify the caller's certificate
+static int always_true_callback(X509_STORE_CTX *ctx, void *arg)
+{
+#if 1
+    (void) ctx;
+    (void) arg;
+#else
+    fprintf(stderr, "cert callback = true\n");
+
+    if (ctx->cert)
+    {
+        char subject_name[256];
+        char issuer_name[256];
+        X509_NAME_oneline(X509_get_subject_name(ctx->cert), subject_name, 256);
+        X509_NAME_oneline(X509_get_issuer_name(ctx->cert), issuer_name, 256);
+        fprintf(stderr, "Verifying %s\n  issuer: %s\n", subject_name, issuer_name);
+    }
+#endif
+    return 1;
+}
+
+SSL_CTX* ssl_create_context(char *client_certificate, char *client_key, char *ca_certificate)
+{
+    bool err = false;
+    ssl_error = 0;
+
+    SSL_CTX* ctx = SSL_CTX_new(SSLv23_client_method());
+    if (!ctx)
+    {
+        sprintf(ssl_saved_error, "SSL_CTX_new failed!\n");
+        return 0;
+    }
+
+    do
+    {
+        SSL_CTX_set_verify(ctx,SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+        SSL_CTX_set_verify_depth(ctx, 4);
+        SSL_CTX_set_cert_verify_callback(ctx, always_true_callback, 0);
+
+        if (SSL_CTX_load_verify_locations(ctx, ca_certificate, NULL) != 1)
+        {
+            sprintf(ssl_saved_error, "Failed to load root certificates\n");
+            ssl_error_type = 1;
+            err = true;
+            break;
+        }
+
+        if (SSL_CTX_use_certificate_file(ctx, client_certificate, SSL_FILETYPE_PEM) != 1)
+        {
+            sprintf(ssl_saved_error, "Failed to Load the client certificate\n");
+            ssl_error_type = 2;
+            err = true;
+            break;
+        }
+
+        if (SSL_CTX_use_PrivateKey_file(ctx, client_key, SSL_FILETYPE_PEM) != 1)
+        {
+            sprintf(ssl_saved_error, "Failed to Load the client key\n");
+            ssl_error_type = 2;
+            err = true;
+            break;
+        }
+    } while (0);
+
+    if (err)
+    {
+        ssl_error = ERR_get_error();
+        SSL_CTX_free(ctx);
+        ctx = 0;
+    }
+
+    return ctx;
+}
+
+const char* openssl_strerror()
+{
+    static int error_strings_loaded = 0;
+
+    if (!error_strings_loaded)
+    {
+        SSL_load_error_strings();
+        error_strings_loaded = 1;
+    }
+	return ERR_error_string(ERR_get_error(), NULL);
+}
+
+//------------------------------------------------------------------------------
+BIO* ssl_connect(SSL_CTX *ctx, const char* server_address, const char* server_port, SSL_SESSION** session)
+{
+    /* Set up the TLS connection to the KMIP server. */
+    SSL* ssl = 0;
+    BIO* bio = 0;
+    ssl_error = 0;
+
+    bio = BIO_new_ssl_connect(ctx);
+    if(bio == NULL)
+    {
+        sprintf(ssl_saved_error, "BIO_new_ssl_connect failed: %s\n", openssl_strerror());
+        ssl_error = ERR_get_error();
+        return (0);
+    }
+
+    BIO_set_conn_hostname(bio, server_address);
+    BIO_set_conn_port(bio, server_port);
+    BIO_get_ssl(bio, &ssl);
+    SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
+    if (*session)
+        SSL_set_session(ssl, *session);
+
+    if (BIO_do_connect(bio) != 1)
+    {
+        const char* certerr = NULL;
+        int rc = ERR_peek_error();
+        if ( rc )
+        {
+            if ( ( ERR_GET_LIB(rc) == ERR_LIB_SSL ) &&
+                 ( ERR_GET_REASON(rc) == SSL_R_CERTIFICATE_VERIFY_FAILED ) )
+            {
+                int certrc = SSL_get_verify_result(ssl);
+                certerr = (char *)X509_verify_cert_error_string(certrc);
+            }
+        }
+
+        ssl_error = rc;
+        sprintf(ssl_saved_error,"BIO_do_connect failed: %s\n", openssl_strerror());
+        if (certerr)
+            sprintf(ssl_saved_error, "SSL cert error: %s\n", certerr );
+
+        BIO_free_all(bio);
+        return(0);
+    }
+
+
+    if (SSL_session_reused(ssl)) {
+        ssl_reused = 1;
+        // printf("REUSED SESSION\n");
+    } else {
+        ssl_reused = 0;
+        // printf("NEW SESSION\n");
+    }
+
+    if (*session)
+        SSL_SESSION_free(*session);
+
+    *session = SSL_get1_session(ssl);
+
+    return bio;
+}
+
+void ssl_disconnect(BIO* bio)
+{
+    BIO_ssl_shutdown(bio);
+    BIO_free_all(bio);
+}
+
+

--- a/ssl_connect.h
+++ b/ssl_connect.h
@@ -1,0 +1,21 @@
+
+#include <openssl/ssl.h>
+
+#if 0
+int do_ssl_connect(char *server_address, char *server_port, char *client_certificate, char *client_key, char *ca_certificate,
+                   SSL_CTX** outctx, BIO** outbio) ;
+
+int do_ssl_free(SSL_CTX** ctx, BIO** bio);
+#endif
+
+
+extern char ssl_saved_error[];
+extern int  ssl_reused;
+extern int  ssl_error;
+extern int  ssl_error_type;  // 1=server, 2=client
+
+void ssl_initialize();
+const char* openssl_strerror();
+SSL_CTX* ssl_create_context(char *client_certificate, char *client_key, char *ca_certificate);
+BIO*     ssl_connect(SSL_CTX *ctx, const char* server_address, const char* server_port, SSL_SESSION** session);
+void ssl_disconnect(BIO* bio);


### PR DESCRIPTION
The Query operation can be used by the client to test the connection to the server, ie. verify the certificates work with just a simple operation.

The Locate operation is used to find a key that has been created with a name/group attribute.

Both of these have a couple of unimplemented functions because I was focused on the client side.

I added ssl_connect.* files to separate the KMIP and SSL functions.  It uses sessions to allow multiple KMIP operations to reuse the connection.

I added kmip_get_last_error() function to allow using the high level api, but still be able to report on errors.

I was not sure how the tests were created.  These have been tested with PyKMIP and a couple of commercial KMS products.
