### PR TITLE
Added stdio include to kmip.h

### DIFF
--- a/kmip.h
+++ b/kmip.h
@@ -11,7 +11,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-
+#include <stdio.h>
 /*
 Types and Constants
 */


### PR DESCRIPTION
This error occurs many times during ```make``` when using kmip.h:

    kmip.h:1490:24: error: unknown type name ‘FILE’;

Added stdio.h to the header to fix this problem.